### PR TITLE
Not really an sh script

### DIFF
--- a/git-open
+++ b/git-open
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Opens the github page for a repo/branch in your browser.
 # https://github.com/paulirish/git-open/


### PR DESCRIPTION
`/bin/sh` doesn't have to be a symlink to `/bin/bash`. On my system it links to `dash` instead.

Because of that, the script does not work:
```
./git-open: 13: ./git-open: [[: not found
./git-open: 39: ./git-open: Bad substitution
```