### PR TITLE
Discard git-rev-parse's output

### DIFF
--- a/git-open
+++ b/git-open
@@ -8,7 +8,7 @@
 
 
 # are we in a git repo?
-git rev-parse --is-inside-work-tree 2>/dev/null
+git rev-parse --is-inside-work-tree &>/dev/null
 
 if [[ $? != 0 ]]
 then


### PR DESCRIPTION
This PR stops `rev-parse` from writing `true` on success to the console.

The user doesn't need any extra confirmation: he either gets “Not a git repository” message, or new tab opens. Beside that, the "true" message is just meaningless.