### PR TITLE
docs(README.md): add information about chmod +x

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Put the bash script in `~/bin/` and make sure that folder's in your PATH.
 
 ```sh
 wget -O ~/bin/git-open https://raw.githubusercontent.com/paulirish/git-open/master/git-open
+chmod +x ~/bin/git-open
 ```
 
 ## Thx


### PR DESCRIPTION
Without making script executable, you will get this message: `fatal: cannot exec 'git-open': Permission denied`