### PR TITLE
Create Makefile for installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
+GETPATH = $(firstword $(subst :, ,$1))
+BINPATH = $(call GETPATH, ${PATH}) 
+GOPATH = $(join ${BINPATH}, /git-open)
 
 install:
-	@cp -r ./git-open /usr/local/bin
-	@chmod +x /usr/local/bin/git-open
+	@cp -r ./git-open ${GOPATH}
+	@chmod +x ${GOPATH}
 
 clean:
-	@rm /usr/local/bin/git-open
+	@rm ${GOPATH}
+
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+
+install:
+	@cp -r ./git-open /usr/local/bin
+	@chmod +x /usr/local/bin/git-open
+
+clean:
+	@rm /usr/local/bin/git-open
+

--- a/README.md
+++ b/README.md
@@ -20,11 +20,9 @@ A command-line script to open the GitHub page, or website for a repository.
 
 ## Installation
 
-Put the bash script in `~/bin/` and make sure that folder's in your PATH.
-
-```sh
-curl -o ~/bin/git-open https://raw.githubusercontent.com/paulirish/git-open/master/git-open
-chmod +x ~/bin/git-open
+```sh 
+git clone https://github.com/paulirish/git-open.git && cd ./git-open
+make
 ```
 
 ## Thx


### PR DESCRIPTION
Hi guys, I add a Makefile for installing git-open with make after cloning the repo.
```sh
git clone https://github.com/paulirish/git-open.git && cd ./git-open
make
```

The idea is to use the user defined PATH, here's the code
<a href="https://github.com/Urucas/git-open/blob/master/Makefile">https://github.com/Urucas/git-open/blob/master/Makefile</a>
