### PR TITLE
Make hash character url friendly

### DIFF
--- a/git-open
+++ b/git-open
@@ -42,7 +42,8 @@ else
     branch="$2"
 fi
 
-# Make hash character url friendly
+# Make # and % characters url friendly
+branch=${branch//%/%25}
 branch=${branch//#/%23}
 
 # URL normalization

--- a/git-open
+++ b/git-open
@@ -42,6 +42,9 @@ else
     branch="$2"
 fi
 
+# Make hash character url friendly
+branch=${branch//#/%23}
+
 # URL normalization
 # Github 
 if grep -q github <<<$giturl; then

--- a/git-open
+++ b/git-open
@@ -43,7 +43,7 @@ else
 fi
 
 # Make # and % characters url friendly
-branch=${${branch//%/%25}//#/%23}
+branch=${branch//%/%25} && branch=${branch//#/%23}
 
 # URL normalization
 # Github 

--- a/git-open
+++ b/git-open
@@ -43,8 +43,7 @@ else
 fi
 
 # Make # and % characters url friendly
-branch=${branch//%/%25}
-branch=${branch//#/%23}
+branch=${${branch//%/%25}//#/%23}
 
 # URL normalization
 # Github 


### PR DESCRIPTION
I tried out using branch name like `issue-#1`, but found out it didn't work with `git open`. This fix works for me :)