### PR TITLE
Add support for repos cloned via SSH

### DIFF
--- a/git-open
+++ b/git-open
@@ -51,6 +51,10 @@ if grep -q gist.github <<<$giturl; then
 # Github
 elif grep -q github <<<$giturl; then
   giturl=${giturl/git\@github\.com\:/https://github.com/}
+
+  # handle SSH protocol (links like ssh://git@github.com/user/repo)
+  giturl=${giturl/#ssh\:\/\/git\@github\.com\//https://github.com/}
+
   providerUrlDifference=tree
 
 # bitbucket


### PR DESCRIPTION
Support repos with URL format like this: `ssh://git@github.com/user/repo.git`  
Fix #29 