### PR TITLE
Add git-home as an alias for git-open

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "cli"
   ],
   "bin": {
-    "git-open": "git-open"
+    "git-open": "git-open",
+    "git-home" : "git-open"
   },
   "author": "Paul Irish",
   "license": "MIT",


### PR DESCRIPTION
Added git-home as a synonym becasue  I'm too stupid to remember that it's `brew home` and `git open`.
