### PR TITLE
Full GitHub Enterprise Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ git config --global gitopen.gitlab.domain [yourdomain.here]
 git config gitopen.gitlab.domain [yourdomain.here] # in your local repository
 ```
 ##GitHub Enterprise
-To configure GitHub enterrpise support, you need to set gitopen.enterprise.domain the Enterprise installation's root such as `github.mycompany.com`:
+To configure GitHub Enterpise support, you need to set gitopen.enterprise.domain to the Enterprise installation's root such as `github.mycompany.com`:
 
 ```
 git config --global gitopen.enterprise.domain [yourdomain.here]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To configure GitHub enterrpise support, you need to set gitopen.enterprise.domai
 
 ```
 git config --global gitopen.enterprise.domain [yourdomain.here]
-#or
+# or
 git config gitopen.enterprise.domain [yourdomain.here] # in your local repository
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ npm install --global git-open
 * Atlassian Stash
 * Gitlab.com
 * Gitlab custom hosted (see below)
-
+* GitHub Enterprise (see below)
 
 ## Gitlab support
 To configure gitlab support you need to set gitopen.gitlab.domain:
@@ -43,7 +43,14 @@ git config --global gitopen.gitlab.domain [yourdomain.here]
 # or
 git config gitopen.gitlab.domain [yourdomain.here] # in your local repository
 ```
+##GitHub Enterprise
+To configure GitHub enterrpise support, you need to set gitopen.enterprise.domain the Enterprise installation's root such as `github.mycompany.com`:
 
+```
+git config --global gitopen.enterprise.domain [yourdomain.here]
+#or
+git config gitopen.enterprise.domain [yourdomain.here] # in your local repository
+```
 
 ## Thx
 @jasonmccreary did [all the hard work](https://github.com/jasonmccreary/gh)

--- a/git-open
+++ b/git-open
@@ -41,14 +41,13 @@ fi
 #   github.com/paulirish/git-open/pull/24
 branch=${branch//%/%25} && branch=${branch//#/%23}
 
-# URL normalization
-# Github gists
+#Check if the key for an enterprise root exists
 git config --get gitopen.enterprise.domain
 enterprise=$?
 
-
+#If the key exists, this repository has been configured for a GitHub enterprise root
 if [ $enterprise -eq 0 ]; then
-  # enterprise domain
+  # retrieve the enterprise domain
   enterprise_domain=$(git config --get gitopen.enterprise.domain)
   giturl=${giturl/git\@${enterprise_domain}:/https://${enterprise_domain}/}
 
@@ -57,6 +56,8 @@ if [ $enterprise -eq 0 ]; then
 
   providerUrlDifference=tree
 
+# URL normalization
+# Github gists
 elif grep -q gist.github <<<$giturl; then
   giturl=${giturl/git\@gist.github\.com\:/https://gist.github.com}
   providerUrlDifference=tree

--- a/git-open
+++ b/git-open
@@ -15,7 +15,6 @@ if [[ $? != 0 ]]; then
   exit 1
 fi
 
-
 # assume origin if not provided
 # fallback to upstream if neither is present.
 remote="origin"
@@ -44,7 +43,21 @@ branch=${branch//%/%25} && branch=${branch//#/%23}
 
 # URL normalization
 # Github gists
-if grep -q gist.github <<<$giturl; then
+git config --get gitopen.enterprise.domain
+enterprise=$?
+
+
+if [ $enterprise -eq 0 ]; then
+  # enterprise domain
+  enterprise_domain=$(git config --get gitopen.enterprise.domain)
+  giturl=${giturl/git\@${enterprise_domain}:/https://${enterprise_domain}/}
+
+  # handle SSH protocol (links like ssh://git@github.com/user/repo)
+  giturl=${giturl/#ssh\:\/\/git\@${enterprise_domain}:/https://${enterprise_domain}/}
+
+  providerUrlDifference=tree
+
+elif grep -q gist.github <<<$giturl; then
   giturl=${giturl/git\@gist.github\.com\:/https://gist.github.com}
   providerUrlDifference=tree
 


### PR DESCRIPTION
This is the third such GH Enterprise PR, however I think my solution is fairly robust, following the same pattern as GitLab integration. The GitHub Enterprise root is set as a git config variable, and if such a variable exists, that root is used instead of the traditional `github.com` root.