### PR TITLE
Make installable as a ZSH plugin by o-m-z compatible ZSH frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Antigen will handle cloning the plugin for you automatically the next time you s
 
 1. `cd ~/.oh-my-zsh/custom/plugins`
 2. `git clone git@github.com:paulirish/git-open.git gitopen`
-3. Add git-open to your plugin list - edit `~.zshrc` and change `plugins=(...)` to `plugins=(... gitopen)`
+3. Add git-open to your plugin list - edit `~/.zshrc` and change `plugins=(...)` to `plugins=(... gitopen)`
 
 ### [Zgen](https://github.com/tarjoilija/zgen)
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,29 @@ Type `git open` to open the GitHub page or website for a repository in your brow
 
 ## Installation
 
+### Without using a framework
 
 ```sh
 npm install --global git-open
 ```
+
+### Using a ZSH Framework
+
+#### [Antigen](https://github.com/zsh-users/antigen)
+
+Add `antigen bundle paulirish/git-open` to your `.zshrc` with your other bundle commands.
+
+Antigen will handle cloning the plugin for you automatically the next time you start zsh, and periodically checking for updates to the git repository. You can also add the plugin to a running zsh with `antigen bundle paulirish/git-open` for testing before adding it to your `.zshrc`.
+
+### [Oh-My-Zsh](http://ohmyz.sh/)
+
+1. `cd ~/.oh-my-zsh/custom/plugins`
+2. `git clone git@github.com:paulirish/git-open.git gitopen`
+3. Add git-open to your plugin list - edit `~.zshrc` and change `plugins=(...)` to `plugins=(... gitopen)`
+
+### [Zgen](https://github.com/tarjoilija/zgen)
+
+Add `zgen load paulirish/git-open` to your .zshrc file in the same function you're doing your other `zgen load` calls in. ZGen will take care of cloning the repository the next time you run `zgen save`, and will also periodically check for updates to the git repository.
 
 
 #### Supported:

--- a/git-open.plugin.zsh
+++ b/git-open.plugin.zsh
@@ -3,4 +3,4 @@
 # Make git-open easy to install and keep up to date if you're using a
 # ZSH framework like Zgen or Antigen
 
-  export PATH=${PATH}:$(dirname $0)
+  export PATH=$(dirname $0):${PATH}

--- a/git-open.plugin.zsh
+++ b/git-open.plugin.zsh
@@ -1,0 +1,6 @@
+# This plugin is MIT licensed to match the git-open license.
+#
+# Make git-open easy to install and keep up to date if you're using a
+# ZSH framework like Zgen or Antigen
+
+  export PATH=${PATH}:$(dirname $0)


### PR DESCRIPTION
Add ZSH plugin support. This lets git-aware frameworks like [Antigen](https://github.com/zsh-users/antigen) and [Zgen](https://github.com/tarjoilija/zgen) handle automatically checking for updates.