### PR TITLE
Make spacing after header lines consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ for testing before adding it to your `.zshrc`.
    `plugins=(...)` to `plugins=(... gitopen)`
 
 ##### [Zgen](https://github.com/tarjoilija/zgen)
+
 Add `zgen load paulirish/git-open` to your .zshrc file in the same function
 you're doing your other `zgen load` calls in. ZGen will take care of cloning
 the repository the next time you run `zgen save`, and will also periodically
@@ -99,11 +100,12 @@ that only works with GitHub but can open user profile pages, too.
 See the contributors tab for a growing list of people who have submitted PRs.
 
 ## Contributing
+
 Please provide examples of the URLs you are parsing with each PR.
 
 ## License
 
-Copyright Jason McCreary & Paul Irish. Licensed under MIT.  
+Copyright Jason McCreary & Paul Irish. Licensed under MIT.
 http://opensource.org/licenses/MIT
 
 ## Changelog


### PR DESCRIPTION
* There were a couple of headers that didn't have a blank line after them, make them consistent with the others.
* Removed trailing spaces