### PR TITLE
Easily track and open the relevant github issue via branch naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Type `git open` to open the GitHub page or website for a repository in your brow
 
 ## Usage
     git open [remote-name] [branch-name]
+    git open issue
 
 ![git open2015-01-24 13_51_18](https://cloud.githubusercontent.com/assets/39191/5889192/244a0b72-a3d0-11e4-8ab9-55fc64228aaa.gif)
 
@@ -17,6 +18,9 @@ Type `git open` to open the GitHub page or website for a repository in your brow
     $ git open upstream master
     > open https://github.com/REMOTE_UPSTREAM_USER/CURRENT_REPO/tree/master
 
+    On a branch with the naming convention of issues/#123
+    $ git open issue
+    > open https://github.com/REMOTE_UPSTREAM_USER/CURRENT_REPO/issues/123
 
 ## Installation
 
@@ -24,6 +28,12 @@ Type `git open` to open the GitHub page or website for a repository in your brow
 ```sh
 npm install --global git-open
 ```
+
+Installing the version you downloaded (in the current director)
+```sh
+npm install --global ./
+```
+
 
 
 #### Supported:

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Installing the version you downloaded (in the current director)
 npm install --global ./
 ```
 
+Installing a specific fork
+```sh
+npm install --global https://github.com/kangaroo5383/git-open.git
+```
 
 
 #### Supported:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ browser.
 ## Usage
 
     git open [remote-name] [branch-name]
-    git open issue (only implemented github support, feel free to fix the other ones.)
+    git open issue 
+
+(only implemented github support, feel free to fix the other ones.)
 
 ### Examples
 
@@ -37,15 +39,6 @@ You can use also `npm` to install this package:
 
     npm install --global git-open
 
-Installing the version you downloaded (in the current director)
-```sh
-npm install --global ./
-```
-
-Installing a specific fork
-```sh
-npm install --global https://github.com/kangaroo5383/git-open.git
-```
 
 #### Using Windows Powershell
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Type `git open` to open the GitHub page or website for a repository in your brow
 
 ## Usage
     git open [remote-name] [branch-name]
-    git open issue
+    git open issue (only implemented github support, feel free to fix the other ones.)
 
 ![git open2015-01-24 13_51_18](https://cloud.githubusercontent.com/assets/39191/5889192/244a0b72-a3d0-11e4-8ab9-55fc64228aaa.gif)
 

--- a/git-open
+++ b/git-open
@@ -25,7 +25,6 @@ if [ -n "$1" ]; then
     regex='^issue'
     if [[ $currentBranch =~ $regex ]]; then
       issue=${currentBranch#*#}
-      echo "issue for $issue"
     else
       echo "'git open issue' expect branch naming to be issues/#123"
       exit 0

--- a/git-open
+++ b/git-open
@@ -20,7 +20,19 @@ fi
 # fallback to upstream if neither is present.
 remote="origin"
 if [ -n "$1" ]; then
-  remote="$1"
+  if [ "$1" == "issue" ]; then
+    currentBranch=$(git symbolic-ref -q --short HEAD)
+    regex='^issue'
+    if [[ $currentBranch =~ $regex ]]; then
+      issue=${currentBranch#*#}
+      echo "issue for $issue"
+    else
+      echo "'git open issue' expect branch naming to be issues/#123"
+      exit 0
+    fi
+  else
+    remote="$1"
+  fi
 fi
 
 remote_url="remote.${remote}.url"
@@ -87,7 +99,9 @@ else
 fi
 giturl=${giturl%\.git}
 
-if [ -n "$branch" ]; then
+if [ -n "$issue" ]; then
+  giturl="${giturl}/issues/${issue}"
+elif [ -n "$branch" ]; then
   giturl="${giturl}/${providerUrlDifference}/${branch}"
 fi
 


### PR DESCRIPTION
As an implementation of git flow, we've started using the convention of one issue per branch for development with the naming convention `issues/#123`.  It's great for keeping PRs contained and development work distraction free.  Perhaps this is something useful for the community using git-open as well.   

```
On a branch with the naming convention of issues/#123
$ git open issue
> open https://github.com/REMOTE_UPSTREAM_USER/CURRENT_REPO/issues/123
```

To contribute to this project, would I also have to add support to the other platform as well? Thank you for your considerations.