### PR TITLE
Supports separate URLs in the repo and the web

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,19 @@ git-open can automatically guess the corresponding repository page for remotes
 
 #### GitLab support
 
-To configure GitLab support you need to set `gitopen.gitlab.domain`:
+To configure GitLab support you need to set some options.
+
+| option name               | description                                                | example            |
+| ------------------------- | ---------------------------------------------------------- | ------------------ |
+| gitopen.gitlab.domain     | The (web)domain name that will work for most of the people | gitlab.example.com |
+| gitopen.gitlab.ssh.domain | A specific ssh domain name, *if needed*                    | git.example.com    |
+| gitopen.gitlab.ssh.port   | A specific ssh port, *if needed*                           | 10022              |
 
 ```sh
 # use --global to set across all repos, instead of just the local one
-git config [--global] gitopen.gitlab.domain [yourdomain.here]
+git config [--global] gitopen.gitlab.domain [value]
+git config [--global] gitopen.gitlab.ssh.domain [value]
+git config [--global] gitopen.gitlab.ssh.port [value]
 ```
 
 ## Related projects / alternatives

--- a/git-open
+++ b/git-open
@@ -92,9 +92,9 @@ elif grep -q "/scm/" <<<$giturl; then
 else
   # custom GitLab
   gitlab_domain=$(git config --get gitopen.gitlab.domain)
-  gitlab_ssh_domain=$(git config --get gitopen.gitlab.ssh-domain)
+  gitlab_ssh_domain=$(git config --get gitopen.gitlab.ssh.domain)
   gitlab_ssh_domain=${gitlab_ssh_domain:-$gitlab_domain}
-  gitlab_port=$(git config --get gitopen.gitlab.port)
+  gitlab_ssh_port=$(git config --get gitopen.gitlab.ssh.port)
   if [ -n "$gitlab_domain" ]; then
     if egrep -q "${gitlab_domain}|${gitlab_ssh_domain}" <<<$giturl; then
 
@@ -108,8 +108,8 @@ else
       giturl=${giturl/git\@${gitlab_ssh_domain}/${gitlab_domain}/}
 
       # remove SSH port
-      if [ -n "$gitlab_port" ]; then
-        giturl=${giturl/\/:${gitlab_port}\///}
+      if [ -n "$gitlab_ssh_port" ]; then
+        giturl=${giturl/\/:${gitlab_ssh_port}\///}
       fi
       providerUrlDifference=tree
     fi

--- a/git-open
+++ b/git-open
@@ -92,18 +92,20 @@ elif grep -q "/scm/" <<<$giturl; then
 else
   # custom GitLab
   gitlab_domain=$(git config --get gitopen.gitlab.domain)
+  gitlab_ssh_domain=$(git config --get gitopen.gitlab.ssh-domain)
+  gitlab_ssh_domain=${gitlab_ssh_domain:-$gitlab_domain}
   gitlab_port=$(git config --get gitopen.gitlab.port)
   if [ -n "$gitlab_domain" ]; then
-    if grep -q "$gitlab_domain" <<<$giturl; then
+    if egrep -q "${gitlab_domain}|${gitlab_ssh_domain}" <<<$giturl; then
 
       # Handle GitLab's default SSH notation (like git@gitlab.domain.com:user/repo)
-      giturl=${giturl/git\@${gitlab_domain}\:/https://${gitlab_domain}/}
+      giturl=${giturl/git\@${gitlab_ssh_domain}\:/https://${gitlab_domain}/}
 
       # handle SSH protocol (links like ssh://git@gitlab.domain.com/user/repo)
       giturl=${giturl/#ssh\:\/\//https://}
 
       # remove git@ from the domain
-      giturl=${giturl/git\@${gitlab_domain}/${gitlab_domain}/}
+      giturl=${giturl/git\@${gitlab_ssh_domain}/${gitlab_domain}/}
 
       # remove SSH port
       if [ -n "$gitlab_port" ]; then


### PR DESCRIPTION
On a GitLab server.

ex.

---

* repo
    * `git@git.example.com:namespace/project.git`
* web
    * `https://gitlab.example.com/namespace/project`

Then,

    $ git config gitopen.gitlab.domain gitlab.example.com
    $ git config gitopen.gitlab.ssh-domain git.example.com
    $ git open

Then open the web url in your web browser.