### PR TITLE
Fix unspported Bitbucket Server URL

### DIFF
--- a/git-open
+++ b/git-open
@@ -85,8 +85,10 @@ elif grep -q "/scm/" <<<$giturl; then
   if [[ $giturl =~ $re ]]; then
     giturl=${BASH_REMATCH[1]}/projects/${BASH_REMATCH[2]}/repos/${BASH_REMATCH[3]}
 
-    giturl=${giturl/http\:\/\/[^\@]*\@/http\:\/\/}
-    giturl=${giturl/https\:\/\/[^\@]*\@/https\:\/\/}
+    # Bitbucket Server can't handle an origin which includes the basicAuth part, so it gets stripped
+    if [[ $giturl =~ ^http(s?)://([^@]*@)(.*)$ ]] ; then
+      giturl="http${BASH_REMATCH[1]}://${BASH_REMATCH[3]}"
+    fi
   
     providerUrlDifference=browse
     branch="?at=refs%2Fheads%2F${branch}"

--- a/git-open
+++ b/git-open
@@ -84,6 +84,10 @@ elif grep -q "/scm/" <<<$giturl; then
   re='(.*)/scm/(.*)/(.*)\.git'
   if [[ $giturl =~ $re ]]; then
     giturl=${BASH_REMATCH[1]}/projects/${BASH_REMATCH[2]}/repos/${BASH_REMATCH[3]}
+
+    giturl=${giturl/http\:\/\/[^\@]*\@/http\:\/\/}
+    giturl=${giturl/https\:\/\/[^\@]*\@/https\:\/\/}
+  
     providerUrlDifference=browse
     branch="?at=refs%2Fheads%2F${branch}"
   fi


### PR DESCRIPTION
Bitbucket server does not support the `<username>` part in the created URL (`<protocol>://<username>@<url>/`)
I propose to strip these from the URL before opening.