### PR TITLE
Handle GitHub urls without the git user

### DIFF
--- a/git-open
+++ b/git-open
@@ -62,6 +62,9 @@ if grep -q gist.github <<<$giturl; then
 # GitHub
 elif grep -q github <<<$giturl; then
   giturl=${giturl/git\@github\.com\:/https://github.com/}
+  
+  # handle urls with the git user
+  giturl=${giturl/#github\.com\:/https://github.com/}
 
   # handle SSH protocol (links like ssh://git@github.com/user/repo)
   giturl=${giturl/#ssh\:\/\/git\@github\.com\//https://github.com/}


### PR DESCRIPTION
In my ssh config if specified that all connections with github.com should use the `git` user. So when cloning a repo I can type:
```bash
git clone github.com:paulirish/git-open.git
``` 
instead of
```bash
git clone git@github.com:paulirish/git-open.git
``` 

This PR contains a fix for repos that have been cloned without specifying the `git` user.