### PR TITLE
Remove username from <giturl> for BitBucket

### DIFF
--- a/git-open
+++ b/git-open
@@ -74,6 +74,9 @@ elif grep -q bitbucket <<<$giturl; then
   # handle SSH protocol (change ssh://https://bitbucket.org/user/repo to https://bitbucket.org/user/repo)
   giturl=${giturl/#ssh\:\/\/git\@/https://}
 
+  # remove username
+  giturl=${giturl//\/\/*@bitbucket.org///bitbucket.org}
+
   rev="$(git rev-parse HEAD)"
   git_pwd="$(git rev-parse --show-prefix)"
   providerUrlDifference="src/${rev}/${git_pwd}"


### PR DESCRIPTION
The username prefix `username@bitbucket.org` caused a _Possible Phishing Website_ warning
on Safari which persisted across page visits on BitBucket.

Removing the username from the url fixes this issue.

![screen shot 2017-05-26 at 2 38 12 pm](https://cloud.githubusercontent.com/assets/6083067/26513561/ffcd8ae8-4220-11e7-9a85-8fadf69482ee.png)
