### PR TITLE
Handle urls without the github domain

### DIFF
--- a/git-open
+++ b/git-open
@@ -62,13 +62,13 @@ if grep -q gist.github <<<"$giturl"; then
 # GitHub
 elif grep -q github <<<"$giturl"; then
   giturl=${giturl/git\@github\.com\:/https://github.com/}
-  
+
   # handle urls with the git user
   giturl=${giturl/#github\.com\:/https://github.com/}
-  
+
   # handle urls without the github domain with git user
   giturl=${giturl/#github\:/https://github.com/}
-  
+
   # handle urls without the github domain
   giturl=${giturl/#ssh\:\/\/git\@github\//https://github.com/}
 

--- a/git-open
+++ b/git-open
@@ -65,6 +65,12 @@ elif grep -q github <<<"$giturl"; then
   
   # handle urls with the git user
   giturl=${giturl/#github\.com\:/https://github.com/}
+  
+  # handle urls without the github domain with git user
+  giturl=${giturl/#github\:/https://github.com/}
+  
+  # handle urls without the github domain
+  giturl=${giturl/#ssh\:\/\/git\@github\//https://github.com/}
 
   # handle SSH protocol (links like ssh://git@github.com/user/repo)
   giturl=${giturl/#ssh\:\/\/git\@github\.com\//https://github.com/}


### PR DESCRIPTION
In my ssh config if specified that all connections with github should use the github.com domain. So when cloning a repo I can type:
``` bash
git clone git@github:paulirish/git-open.git
```
or
``` bash
git clone github:paulirish/git-open.git
```
instead of
``` bash
git clone git@github.com:paulirish/git-open.git
```
This PR contains a fix for repos that have been cloned without specifying the github domain.