### PR TITLE
Add support for open.default.remote config

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ If your Gitlab custom hosted is serving `http` you can also specify this:
 git config [--global] gitopen.gitlab.protocol http
 ```
 
+### Default remote
+
+Normally `git open` opens the remote named `origin`. When you fork a project
+and add a remote named `upstream` you often want that upstream to be opened
+as the default remote. To accomplice this, you can do this:
+
+```sh
+git config open.default.remote upstream
+```
+
 ## Alternative projects
 
 See [hub](https://github.com/github/hub) for complete GitHub opening support.

--- a/git-open
+++ b/git-open
@@ -41,10 +41,12 @@ if ! git rev-parse --is-inside-work-tree &>/dev/null; then
   exit 1
 fi
 
-# choose remote. priority to: provided argument, detected tracked remote, 'origin'
+# choose remote. priority to: provided argument, default in config, detected tracked remote, 'origin'
 branch_name=$(git name-rev --name-only HEAD 2>/dev/null)
 tracked_remote=$(git config "branch.$branch_name.remote")
-remote=${1:-$tracked_remote}
+default_remote=$(git config open.default.remote)
+remote=${1:-$default_remote}
+remote=${remote:-$tracked_remote}
 remote=${remote:-"origin"}
 
 # @TODO ls-remote will also expand "insteadOf" items `giturl=$(git ls-remote --get-url $remote)``


### PR DESCRIPTION
Normally `git open` opens the remote named `origin`. When you fork a project and add a remote named `upstream` you often want that upstream to be opened as the default remote. This introduces a new `git config` setting to fulfill that need.