### PR TITLE
add test for bitbucket server

### DIFF
--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -201,6 +201,18 @@ setup() {
   assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr"
 }
 
+@test "bitbucket: Bitbucket Server branch" {
+  # https://github.com/paulirish/git-open/issues/80
+  git remote set-url origin "https://user@mybb.domain.com/git/scm/ppp/rrr.git"
+  git checkout -B "develop"
+  run ../git-open
+
+  # The following query args work with BB Server:
+  #     at=refs%2Fheads%2Fdevelop, at=develop, at=refs/heads/develop
+  # However /src/develop does not (unlike bitbucket.org)
+  assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr?at=develop"
+}
+
 
 ##
 ## GitLab

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -196,27 +196,27 @@ setup() {
 
 @test "bitbucket: Bitbucket Server" {
   # https://github.com/paulirish/git-open/issues/77#issuecomment-309044010
-  git remote set-url origin "https://user@mybb.domain.com/git/scm/ppp/rrr.git"
+  git remote set-url origin "https://user@mybb.domain.com/scm/ppp/rrr.git"
   run ../git-open
 
   # any of the following are acceptable
-  assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr" ||
-    assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr/browse/?at=master" ||
-    assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr/browse/?at=refs%2Fheads%2Fmaster"
+  assert_output "https://mybb.domain.com/projects/ppp/repos/rrr" ||
+    assert_output "https://mybb.domain.com/projects/ppp/repos/rrr/browse/?at=master" ||
+    assert_output "https://mybb.domain.com/projects/ppp/repos/rrr/browse/?at=refs%2Fheads%2Fmaster"
 }
 
 @test "bitbucket: Bitbucket Server branch" {
   # https://github.com/paulirish/git-open/issues/80
-  git remote set-url origin "https://user@mybb.domain.com/git/scm/ppp/rrr.git"
+  git remote set-url origin "https://user@mybb.domain.com/scm/ppp/rrr.git"
   git checkout -B "develop"
   run ../git-open
 
   # The following query args work with BB Server:
   #     at=refs%2Fheads%2Fdevelop, at=develop, at=refs/heads/develop
   # However /src/develop does not (unlike bitbucket.org)
-  assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr/browse?at=develop" ||
-    assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr/browse?at=refs%2Fheads%2Fdevelop" ||
-    assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr/browse?at=refs/heads/develop"
+  assert_output "https://mybb.domain.com/projects/ppp/repos/rrr/browse?at=develop" ||
+    assert_output "https://mybb.domain.com/projects/ppp/repos/rrr/browse?at=refs%2Fheads%2Fdevelop" ||
+    assert_output "https://mybb.domain.com/projects/ppp/repos/rrr/browse?at=refs/heads/develop"
 
   refute_output --partial "/src/develop"
 }
@@ -224,12 +224,12 @@ setup() {
 
 @test "bitbucket: Bitbucket Server private user repos" {
   # https://github.com/paulirish/git-open/pull/83#issuecomment-309968538
-  git remote set-url origin "https://mybb.domain.com/git/scm/~first.last/rrr.git"
+  git remote set-url origin "https://mybb.domain.com/scm/~first.last/rrr.git"
   git checkout -B "develop"
   run ../git-open
-  assert_output "https://mybb.domain.com/git/projects/~first.last/repos/rrr/browse?at=develop" ||
-    assert_output "https://mybb.domain.com/git/projects/~first.last/repos/rrr/browse?at=refs%2Fheads%2Fdevelop" ||
-    assert_output "https://mybb.domain.com/git/projects/~first.last/repos/rrr/browse?at=refs/heads/develop"
+  assert_output "https://mybb.domain.com/projects/~first.last/repos/rrr/browse?at=develop" ||
+    assert_output "https://mybb.domain.com/projects/~first.last/repos/rrr/browse?at=refs%2Fheads%2Fdevelop" ||
+    assert_output "https://mybb.domain.com/projects/~first.last/repos/rrr/browse?at=refs/heads/develop"
 
 }
 

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -198,7 +198,11 @@ setup() {
   # https://github.com/paulirish/git-open/issues/77#issuecomment-309044010
   git remote set-url origin "https://user@mybb.domain.com/git/scm/ppp/rrr.git"
   run ../git-open
-  assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr"
+
+  # any of the following are acceptable
+  assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr" ||
+    assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr/browse/?at=master" ||
+    assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr/browse/?at=refs%2Fheads%2Fmaster"
 }
 
 @test "bitbucket: Bitbucket Server branch" {
@@ -210,9 +214,24 @@ setup() {
   # The following query args work with BB Server:
   #     at=refs%2Fheads%2Fdevelop, at=develop, at=refs/heads/develop
   # However /src/develop does not (unlike bitbucket.org)
-  assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr?at=develop"
+  assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr/browse?at=develop" ||
+    assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr/browse?at=refs%2Fheads%2Fdevelop" ||
+    assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr/browse?at=refs/heads/develop"
+
+  refute_output --partial "/src/develop"
 }
 
+
+@test "bitbucket: Bitbucket Server private user repos" {
+  # https://github.com/paulirish/git-open/pull/83#issuecomment-309968538
+  git remote set-url origin "https://mybb.domain.com/git/scm/~first.last/rrr.git"
+  git checkout -B "develop"
+  run ../git-open
+  assert_output "https://mybb.domain.com/git/projects/~first.last/repos/rrr/browse?at=develop" ||
+    assert_output "https://mybb.domain.com/git/projects/~first.last/repos/rrr/browse?at=refs%2Fheads%2Fdevelop" ||
+    assert_output "https://mybb.domain.com/git/projects/~first.last/repos/rrr/browse?at=refs/heads/develop"
+
+}
 
 ##
 ## GitLab

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -194,6 +194,14 @@ setup() {
 }
 
 
+@test "bitbucket: Bitbucket Server" {
+  # https://github.com/paulirish/git-open/issues/77#issuecomment-309044010
+  git remote set-url origin "https://user@mybb.domain.com/git/scm/ppp/rrr.git"
+  run ../git-open
+  assert_output "https://mybb.domain.com/git/projects/ppp/repos/rrr"
+}
+
+
 ##
 ## GitLab
 ##


### PR DESCRIPTION
@nwinkler outlined the requirements over here: https://github.com/paulirish/git-open/issues/77#issuecomment-309044010

I believe the patch here implements that, but it currently fails:

| | |
|--|--|
| input |  `https://user@mybb.domain.com/git/scm/ppp/rrr.git` |
| expected output | `https://mybb.domain.com/git/projects/ppp/repos/rrr` |
| current output | `https://user@mybb.domain.com/git/projects/ppp/repos/rrr/browse/?at=refs%2Fheads%2Fmaster` |

Also @derimagia asks some questions about the convention about `/git/scm` at the root of the domain vs just `/scm`:

> @nwinkler Your example doesn't have scm at the root (bb.org/git/scm instead of bb.org/scm/), why's that? Are you  trying to get compatibility with non-root installed git repos?

----------

@nwinkler will need your help on this one :)