### PR TITLE
rewrite: Bitbucket server, and minor tweaks to BROWSER

### DIFF
--- a/git-open
+++ b/git-open
@@ -50,14 +50,16 @@ IFS='/' pathargs=($urlpath)
 providerBranchRef="tree/$branch"
 
 if [[ "$server" == 'bitbucket.org' ]]; then
-  # Bitbucket, see https://github.com/paulirish/git-open/issues/80 for why ?at is needed.
-  providerBranchRef="src?at=$branch"
+  # Bitbucket, see https://github.com/paulirish/git-open/issues/80 for why the ref and the ?at is needed.
+  ref=$(git rev-parse --short $branch)
+  providerBranchRef="src/$ref?at=$branch"
 elif [[ ${pathargs[0]} == 'scm' ]]; then
   # Bitbucket server, which starts with 'scm'
   # Replace the first element, 'scm', with 'projects'. Keep the first argument, the string 'repos', and finally the rest of the arguments.
   pathargs=('projects' ${pathargs[1]} 'repos' "${pathargs[@]:2}")
   IFS='/' urlpath="${pathargs[*]}"
-  providerBranchRef="browse?at=$branch"
+  ref=$(git rev-parse --short $branch)
+  providerBranchRef="browse/$ref?at=$branch"
 fi
 
 # @TODO: support non-https?

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -126,11 +126,9 @@ setup() {
   git remote set-url origin "https://bitbucket.org/kisom/consbri.git"
   git checkout -B "devel"
   run ../git-open
-  assert_output "https://bitbucket.org/kisom/consbri/src/devel"
+  ref=$(git rev-parse --short devel)
+  assert_output "https://bitbucket.org/kisom/consbri/src/$ref?at=devel"
   refute_output --partial "//"
-
-  # alternative destination..
-  # assert_output "https://bitbucket.org/kisom/consbri/src/?at=devel"
 }
 
 @test "bitbucket: open source view with a slash/branch" {
@@ -170,7 +168,8 @@ setup() {
   git remote set-url origin "https://user@bitbucket.example.com/scm/ppp/test-repo.git"
   git checkout -B "bb-server"
   run ../git-open
-  assert_output "https://bitbucket.example.com/projects/ppp/repos/test-repo/browse?at=bb-server"
+  ref=$(git rev-parse -q --short HEAD)
+  assert_output "https://bitbucket.example.com/projects/ppp/repos/test-repo/browse/$ref?at=bb-server"
 }
 
 


### PR DESCRIPTION
Added bitbucket server support. I didn't add functionality for the prefix yet, i'd rather do that for all of them at once (Having a way to supply replacements for the "server" with the root path would take care of Custom Schemes (http vs https), Gitlab having a separate ssh vs http domain, and having custom roots). There any objections to this? Having separate options for every service sounds a little strange rather than supporting them everywhere

From the tests, `gitopen.gitlab.port` should no longer be needed since it just removes the protocol anyway i believe.

This also makes it so you can supply "BROWSER" on all platforms, or was there a reason why this wasn't allowed? Made testing slightly easier to allow it. I had to hardcode "echo" to not be exported to /dev/null since before it was like this for tests, if we add options using getopts a verbosity option would be nice here