### PR TITLE
Fix opening final URL on MSYS

### DIFF
--- a/git-open
+++ b/git-open
@@ -86,8 +86,8 @@ fi
 case $( uname -s ) in
   Darwin)  open='open';;
   MINGW*)  open='start';;
+  MSYS*)   open='start';;
   CYGWIN*) open='cygstart';;
-  MSYS*)   open='powershell.exe –NoProfile Start';;
   *)       open='xdg-open';;
 esac
 


### PR DESCRIPTION
Not sure why the `powershell` is used for MSYS, but it doesn't work. Using `start` works. Only tested with MSYS2.