### PR TITLE
Git styled -h and --issue options

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Type `git open` to open the repo website (GitHub, GitLab, Bitbucket) in your bro
 ```sh
 git open [remote-name] [branch-name]
 
-git open issue
+git open --issue
 ```
 
-(`git open` works with these [hosted repo providers](#supported-remote-repositories), `git open issue` currently only works with GitHub)
+(`git open` works with these [hosted repo providers](#supported-remote-repositories), `git open --issue` currently only works with GitHub)
 
 ### Examples
 
@@ -26,7 +26,7 @@ $ git open someremote
 $ git open someremote somebranch
 # opens https://github.com/PROVIDED_REMOTE_USER/CURRENT_REPO/tree/PROVIDED_BRANCH
 
-$ git open issue
+$ git open --issue
 # If branches use naming convention of issues/#123,
 # opens https://github.com/TRACKED_REMOTE_USER/CURRENT_REPO/issues/123
 ```

--- a/git-open
+++ b/git-open
@@ -1,21 +1,46 @@
 #!/usr/bin/env bash
 
-# Opens the GitHub page for a repo/branch in your browser.
-# https://github.com/paulirish/git-open/
-#
-# git open
-# git open [remote] [branch]
+# Use git-sh-setup, similar to git-rebase
+# https://www.kernel.org/pub/software/scm/git/docs/git-sh-setup.html
+# https://github.com/git/git/blob/master/git-rebase.sh
+# shellcheck disable=SC2034
+OPTIONS_STUCKLONG=t
+# shellcheck disable=SC2034
+OPTIONS_KEEPDASHDASH=
+# shellcheck disable=SC2034
+OPTIONS_SPEC="\
+git open [options]
+git open [remote] [branch]
+git open issue
+--
+  Opens the GitHub page for a repo/branch in your browser.
+  https://github.com/paulirish/git-open/
 
+  Available options are
+i,issue!      open issues page
+"
+
+# https://github.com/koalaman/shellcheck/wiki/SC1090
+# shellcheck source=/dev/null
+. "$(git --exec-path)/git-sh-setup"
+
+# Defaults
+is_issue=0
+protocol="https"
+
+while test $# != 0; do
+  case "$1" in
+  --issue) is_issue=1;;
+  --) shift; break ;;
+  esac
+  shift
+done
 
 # are we in a git repo?
 if ! git rev-parse --is-inside-work-tree &>/dev/null; then
   echo "Not a git repository." 1>&2
   exit 1
 fi
-
-# Defaults
-is_issue=0
-protocol="https"
 
 # If the first argument is 'issue', we want to load the issue page
 if [[ "$1" == 'issue' ]]; then

--- a/git-open
+++ b/git-open
@@ -11,7 +11,6 @@ OPTIONS_KEEPDASHDASH=
 OPTIONS_SPEC="\
 git open [options]
 git open [remote] [branch]
-git open issue
 --
   Opens the GitHub page for a repo/branch in your browser.
   https://github.com/paulirish/git-open/
@@ -40,14 +39,6 @@ done
 if ! git rev-parse --is-inside-work-tree &>/dev/null; then
   echo "Not a git repository." 1>&2
   exit 1
-fi
-
-# If the first argument is 'issue', we want to load the issue page
-if [[ "$1" == 'issue' ]]; then
-  is_issue=1
-
-  # Allow the user to provide other args, aka `git open issue upstream 79`
-  shift
 fi
 
 # choose remote. priority to: provided argument, detected tracked remote, 'origin'

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -21,6 +21,21 @@ setup() {
 }
 
 ##
+## Help
+##
+
+@test "help text" {
+  run ../git-open -h
+  assert_output --partial "usage: git open"
+}
+
+@test "invalid option" {
+  run ../git-open --invalid-option
+  assert_output --partial "error: unknown option \`invalid-option'"
+  assert_output --partial "usage: git open"
+}
+
+##
 ## GitHub
 ##
 
@@ -85,6 +100,15 @@ setup() {
   git checkout -B "fix-issue-36"
   run ../git-open "issue"
   assert_output "https://github.com/paulirish/git-open/issues/36"
+
+  # -i and --issue
+  git checkout -B "fix-issue-37"
+  run ../git-open "--issue"
+  assert_output "https://github.com/paulirish/git-open/issues/37"
+
+  git checkout -B "fix-issue-38"
+  run ../git-open "-i"
+  assert_output "https://github.com/paulirish/git-open/issues/38"
 }
 
 @test "gh: gist" {

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -89,19 +89,13 @@ setup() {
   assert_output "https://github.com/user/repo"
 }
 
-@test "gh: git open issue" {
+@test "gh: git open --issue" {
   # https://github.com/paulirish/git-open/pull/46
   git remote set-url origin "github.com:paulirish/git-open.git"
   git checkout -B "issues/#12"
-  run ../git-open "issue"
+  run ../git-open "--issue"
   assert_output "https://github.com/paulirish/git-open/issues/12"
 
-  # https://github.com/paulirish/git-open/pull/86
-  git checkout -B "fix-issue-36"
-  run ../git-open "issue"
-  assert_output "https://github.com/paulirish/git-open/issues/36"
-
-  # -i and --issue
   git checkout -B "fix-issue-37"
   run ../git-open "--issue"
   assert_output "https://github.com/paulirish/git-open/issues/37"


### PR DESCRIPTION
Use git-sh-setup (like git rebase) to get git styled help `-h` option.

Also added git styled `-i`, `--issue` options as aliases `issue` option