### PR TITLE
Add windows doc for non-powershell users

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ function git-open { cmd /c "C:\Program Files\Git\usr\bin\bash.exe" "~/Documents/
 Set-Alias -Name gop -Value git-open
 ```
 
+#### Using Windows with `cmd` terminal
+
+Save the `git-open` script in any place accessible via your `%PATH%` environment var.
+
 #### Using a ZSH Framework
 
 ##### [Antigen](https://github.com/zsh-users/antigen)


### PR DESCRIPTION
Just to thank you @paulirish, I was about to start writing a script like this, and typed `git open` in Google and found this repo.

As a windows user I already know that any git command can be put in the `%PATH%`, so I wanted to warn newcomers that don't want to use either cygwin or powershell 😄 