### PR TITLE
replace Oh-My-Zsh git clone url in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ for testing before adding it to your `.zshrc`.
 ##### [Oh-My-Zsh](http://ohmyz.sh/)
 
 1. `cd ~/.oh-my-zsh/custom/plugins`
-1. `git clone git@github.com:paulirish/git-open.git`
+1. `git clone https://github.com/paulirish/git-open.git`
 1. Add `git-open` to your plugin list - edit `~/.zshrc` and change
    `plugins=(...)` to `plugins=(... git-open)`
 


### PR DESCRIPTION
Hi,

I was just looking for something like this, great script and thank you.

When I tried to clone the git@github.com:paulirish/git-open.git I got a permission denied, switching it to https did the trick, so here is a PR with a simple fix.