### PR TITLE
Add support for WSL

### DIFF
--- a/git-open
+++ b/git-open
@@ -105,17 +105,17 @@ fi
 
 # get current open browser command
 case $( uname -s ) in
-  Darwin)  open='open';;
-  MINGW*)  open='start';;
-  MSYS*)   open='start';;
-  CYGWIN*) open='cygstart';;
-  *)       # Try to detect WSL (Windows Subsystem for Linux)
-           if uname -r | grep -q Microsoft; then
-             open='powershell.exe'
-             openopt='Start'
-           else
-             open='xdg-open'
-           fi;;
+  Darwin)   open='open';;
+  MINGW*)   open='start';;
+  MSYS*)    open='start';;
+  CYGWIN*)  open='cygstart';;
+  *)        # Try to detect WSL (Windows Subsystem for Linux)
+            if uname -r | grep -q Microsoft; then
+              open='powershell.exe'
+              openopt='Start'
+            else
+              open='xdg-open'
+            fi;;
 esac
 
 # Allow printing the url if BROWSER=echo

--- a/git-open
+++ b/git-open
@@ -109,7 +109,13 @@ case $( uname -s ) in
   MINGW*)  open='start';;
   MSYS*)   open='start';;
   CYGWIN*) open='cygstart';;
-  *)       open='xdg-open';;
+  *)       # Try to detect WSL (Windows Subsystem for Linux)
+           if uname -r | grep -q Microsoft; then
+             open='powershell.exe'
+             openopt='Start'
+           else
+             open='xdg-open'
+           fi;;
 esac
 
 # Allow printing the url if BROWSER=echo
@@ -118,4 +124,4 @@ if [[ $BROWSER != "echo" ]]; then
 fi
 
 # open it in a browser
-${BROWSER:-$open} "$openurl"
+${BROWSER:-$open} $openopt "$openurl"


### PR DESCRIPTION
Basically the subject says it all.

On my Windows Subsystem for Linux (Win10 build 1709, Fall Creator Update) using Ubuntu from the Store:
```sh
$ uname -s
Linux
$ uname -v
#1-Microsoft Wed Dec 31 14:42:53 PST 2014
$ uname -r
4.4.0-43-Microsoft
```

The `$openopt` is needed because `open='powershell.exe Start'` is seen as one command and not as a command and its first parameter.

Tested on WSL Ubuntu bash, Cygwin, Git for Windows Bash and MSYS2