### PR TITLE
Fix BATS testing on WSL

### DIFF
--- a/git-open
+++ b/git-open
@@ -137,9 +137,9 @@ esac
 # Allow printing the url if BROWSER=echo
 if [[ $BROWSER != "echo" ]]; then
   exec &>/dev/null
-else
-  unset openopt
 fi
 
 # open it in a browser
 ${BROWSER:-$open} $openopt "$openurl"
+
+unset openopt

--- a/git-open
+++ b/git-open
@@ -137,6 +137,8 @@ esac
 # Allow printing the url if BROWSER=echo
 if [[ $BROWSER != "echo" ]]; then
   exec &>/dev/null
+else
+  unset openopt
 fi
 
 # open it in a browser


### PR DESCRIPTION
The `$openopt` resulted in unexpected results during testing on WSL