### PR TITLE
allow command to be run in git repo subdirectory

### DIFF
--- a/git-open
+++ b/git-open
@@ -18,6 +18,7 @@ git open [remote] [branch]
   Available options are
 i,issue!      open issues page
 "
+SUBDIRECTORY_OK=true
 
 # https://github.com/koalaman/shellcheck/wiki/SC1090
 # shellcheck source=/dev/null

--- a/git-open
+++ b/git-open
@@ -18,11 +18,10 @@ git open [remote] [branch]
   Available options are
 i,issue!      open issues page
 "
-SUBDIRECTORY_OK=true
 
 # https://github.com/koalaman/shellcheck/wiki/SC1090
 # shellcheck source=/dev/null
-. "$(git --exec-path)/git-sh-setup"
+SUBDIRECTORY_OK='Yes' . "$(git --exec-path)/git-sh-setup"
 
 # Defaults
 is_issue=0


### PR DESCRIPTION
I noticed that the new `git-sh-setup` requires the command is run from the top of the working tree. :/

![image](https://user-images.githubusercontent.com/39191/33500105-7b984186-d68c-11e7-8a6c-f000c7c2e22c.png)

reading the gh-sh-setup source, the fix seems to be just adding this env variable:
https://github.com/git/git/blob/1a4e40aa5dc16564af879142ba9dfbbb88d1e5ff/git-sh-setup.sh#L368