### PR TITLE
Add man page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 sandboxrepo
+git-open.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,7 @@ script:
   - npm run lint:package
   - npm run lint:readme
   - npm run lint:editorconfig
+  - npm run lint:man
   - shellcheck git-open
+  - npm run man
   - ./bats/bin/bats test/*.bats

--- a/README.md
+++ b/README.md
@@ -105,43 +105,7 @@ git-open can automatically guess the corresponding repository page for remotes
 
 ## Configuration 
 
-### Configuring the web destination (aka GitLab support)
-
-To configure GitLab support (or other unique hosting situations) you need to set some options.
-
-| option name               | description  |
-| ------------------------- | ---------------- |
-| open.[gitdomain].domain   | The (web) domain to open based on the provided git repo domain |
-| open.[gitdomain].protocol | The (web) protocol to open based on the provided git repo domain. (Defaults to `https`) |
-
-
-```sh
-git config [--global] open.[gitdomain].domain [value]
-git config [--global] open.[gitdomain].protocol [value]
-```
-
-**Example**
- * Your git remote is at `ssh://git@git.internal.biz:7000/XXX/YYY.git`
- * Your hosted gitlab is `http://repo.intranet/subpath/XXX/YYY`
-
-```sh
-git config [--global] "open.https://git.internal.biz.domain" "repo.intranet/subpath"
-git config [--global] "open.https://git.internal.biz.protocol" "http"
-```
-
-### Configuring which remote to open 
-
-By default, `git open` opens the remote named `origin`. However, if your current branch is [remotely-tracking](https://git-scm.com/book/en/v2/Git-Branching-Remote-Branches#_tracking_branches) a different remote, that tracked remote will be used.
-
-In some instances, you may want to override this behavior. When you fork a project
-and add a remote named `upstream` you often want that upstream to be opened
-rather than your fork. To accomplish this, you can set the `open.default.remote` within your project:
-
-```sh
-git config open.default.remote upstream
-```
-
-This is equivalent to always typing `git open upstream`.
+See the [man page](git-open.1.md) for more information on how to configure `git-open`.
 
 ## Alternative projects
 

--- a/git-open.1.md
+++ b/git-open.1.md
@@ -1,0 +1,138 @@
+# git-open - Open the repository's website in your browser.
+
+
+## SYNOPSIS
+
+`git-open` [remote-name] [branch-name]
+
+`git-open` --issue
+
+
+## DESCRIPTION
+
+`git-open` opens the repository's website in your browser. The major well known
+git hosting services are supported.
+
+
+## OPTIONS
+
+
+`-i`, `--issue`
+  Open the current issue. When the name of the current branch matches the right pattern, 
+  it will open the webpage with that issue. See `EXAMPLES` for more information. 
+  This only works on GitHub, GitLab, Visual Studio Team Services and Team Foundation Server at the moment.
+
+`-h`
+  Show a short help text.
+
+
+## EXAMPLES
+
+```sh
+$ git open
+```
+
+It opens https://github.com/TRACKED_REMOTE_USER/CURRENT_REPO/
+
+```sh
+$ git open someremote
+```
+
+It opens https://github.com/PROVIDED_REMOTE_USER/CURRENT_REPO/
+
+```sh
+$ git open someremote somebranch
+```
+
+It opens https://github.com/PROVIDED_REMOTE_USER/CURRENT_REPO/tree/PROVIDED_BRANCH
+
+```sh
+$ git open --issue
+```
+
+If branches use naming convention of `issues/#123`, it opens
+https://github.com/TRACKED_REMOTE_USER/CURRENT_REPO/issues/123
+
+
+## SUPPORTED REMOTE REPOSITORIES
+
+git-open can automatically guess the corresponding repository page for remotes
+(default looks for `origin`) on the following hosts:
+
+- github.com
+- gist.github.com
+- gitlab.com
+- GitLab CE/EE (self hosted GitLab, see `CONFIGURATION`)
+- bitbucket.org
+- Atlassian Bitbucket Server (formerly _Atlassian Stash_)
+- Visual Studio Team Services
+- Team Foundation Server (on-premises)
+
+
+## CONFIGURATION
+
+To configure git-open you may need to set some `git config` options. 
+You can use `--global` to set across all repos, instead of just the local one.
+
+```sh
+$ git config [--global] option value
+```
+
+### Configuring which remote to open 
+
+By default, `git open` opens the remote named `origin`. However, if your current branch is remotely-tracking a different remote, that tracked remote will be used.
+
+In some instances, you may want to override this behavior. When you fork a project
+and add a remote named `upstream` you often want that upstream to be opened
+rather than your fork. To accomplish this, you can set the `open.default.remote` within your project:
+
+```sh
+git config open.default.remote upstream
+```
+
+This is equivalent to always typing `git open upstream`.
+
+
+### GitLab options
+
+To configure GitLab support (or other unique hosting situations) you may need to set some options.
+
+`open.[gitdomain].domain`
+  The (web) domain to open based on the provided git repo domain.
+
+`open.[gitdomain].protocol`
+  The (web) protocol to open based on the provided git repo domain. Defaults to `https`.
+
+```sh
+git config [--global] open.[gitdomain].domain [value]
+git config [--global] open.[gitdomain].protocol [value]
+```
+
+**Example**
+- Your git remote is at `ssh://git@git.internal.biz:7000/XXX/YYY.git`
+- Your hosted gitlab is `http://repo.intranet/subpath/XXX/YYY`
+
+```sh
+git config [--global] "open.https://git.internal.biz.domain" "repo.intranet/subpath"
+git config [--global] "open.https://git.internal.biz.protocol" "http"
+```
+
+
+## DEBUGGING
+
+You can run `git-open` in `echo` mode, which doesn't open your browser, but just prints the URL to stdout:
+
+```sh
+env BROWSER='echo' ./git-open
+```
+
+
+## AUTHORS
+
+Jason McCreary did the initial hard work. Paul Irish based his project on his work. 
+Since then many contributors have submitted great PRs.
+
+
+## SEE ALSO
+
+git(1), git-remote(1), git-config(1), [Project page](https://github.com/paulirish/git-open)

--- a/git-open.1.md
+++ b/git-open.1.md
@@ -3,19 +3,16 @@
 
 ## SYNOPSIS
 
-`git-open` [remote-name] [branch-name]
-
-`git-open` --issue
+`git open` [--issue] [remote-name] [branch-name]
 
 
 ## DESCRIPTION
 
-`git-open` opens the repository's website in your browser. The major well known
+`git open` opens the repository's website in your browser. The major well known
 git hosting services are supported.
 
 
 ## OPTIONS
-
 
 `-i`, `--issue`
   Open the current issue. When the name of the current branch matches the right pattern, 
@@ -54,10 +51,10 @@ If branches use naming convention of `issues/#123`, it opens
 https://github.com/TRACKED_REMOTE_USER/CURRENT_REPO/issues/123
 
 
-## SUPPORTED REMOTE REPOSITORIES
+## SUPPORTED GIT HOSTING SERVICES
 
 git-open can automatically guess the corresponding repository page for remotes
-(default looks for `origin`) on the following hosts:
+on the following git hosting services:
 
 - github.com
 - gist.github.com
@@ -72,7 +69,7 @@ git-open can automatically guess the corresponding repository page for remotes
 ## CONFIGURATION
 
 To configure git-open you may need to set some `git config` options. 
-You can use `--global` to set across all repos, instead of just the local one.
+You can use `--global` to set across all repos, instead of just the current repo.
 
 ```sh
 $ git config [--global] option value

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "lint:editorconfig": "eclint check git-open* readme* .travis.yml",
     "lint:package": "pjv --recommendations --warnings",
     "lint:readme": "node ./node_modules/markdownlint/lib/markdownlint.js --config markdownlint.json README.md",
-    "test": "npm run unit && npm run lint:package && npm run lint:readme && npm run lint:editorconfig",
+    "lint:man": "node ./node_modules/markdownlint/lib/markdownlint.js --config markdownlint.json git-open.1.md",
+    "man": "marked-man --version \"git-open $npm_package_version\" --manual \"Git manual\" --section 1 git-open.1.md > git-open.1",
+    "test": "npm run unit && npm run lint:package && npm run lint:man && npm run lint:readme && npm run lint:editorconfig",
     "unit": "bats test/",
     "watch": "find . -maxdepth 2 -iname '*bats' -o -iname 'git-open' | entr bats test/"
   },
@@ -42,6 +44,7 @@
   "devDependencies": {
     "eclint": "^2.1.0",
     "markdownlint": "^0.2.0",
+    "marked-man": "^0.2.1",
     "package-json-validator": "^0.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "git-open": "git-open",
     "git-home": "git-open"
   },
+  "man": "./git-open.1",
   "scripts": {
     "lint:editorconfig": "eclint check git-open* readme* .travis.yml",
     "lint:package": "pjv --recommendations --warnings",


### PR DESCRIPTION
Closes #102 

This is an attempt to write a man page.

I took most of the texts from the `README.md`. I replaced the configuration section from that `README.md` with a link to `git-open.1.md` so we don't have to maintain that information in two places. Maybe more can be removed from the `README.md`.

I used [marked-man](https://www.npmjs.com/package/marked-man) to generate the man page from markdown and added it to the `package.json`. So `npm run man` will generate the roff-file that `man` understands. To read it, use `man ./git-open.1`

Not sure though *how* this should be installed. Any suggestions?