### PR TITLE
Bitbucket Server Root Context

### DIFF
--- a/git-open
+++ b/git-open
@@ -126,10 +126,19 @@ fi
 if [[ "$domain" == 'bitbucket.org' ]]; then
   # Bitbucket, see https://github.com/paulirish/git-open/issues/80 for why ?at is needed.
   providerBranchRef="/src?at=$branch"
-elif [[ ${pathargs[0]} == 'scm' ]]; then
-  # Bitbucket server, which starts with 'scm'
-  # Replace the first element, 'scm', with 'projects'. Keep the first argument, the string 'repos', and finally the rest of the arguments.
-  pathargs=('projects' ${pathargs[1]} 'repos' "${pathargs[@]:2}")
+elif [[ "${#pathargs[@]}" -ge 3 && ${pathargs[${#pathargs[@]} - 3]} == 'scm' ]]; then
+  # Bitbucket server always has /scm/ as the third to last segment in the url path, e.g. /scm/ppp/test-repo.git
+  # Anything before the 'scm' is part of the server's root context
+
+  # Check whether there are other context parts before the 'scm' part
+  pathPref=()
+  if [[ "${#pathargs[@]}" -gt 3 ]]; then
+    # If there are other context parts, add them, up to (but not including) the found 'scm'
+    pathPref=("${pathargs[*]:0:${#pathargs[@]} - 3}")
+  fi
+
+  # Replace the 'scm' element, with 'projects'. Keep the first argument, the string 'repos', and finally the rest of the arguments.
+  pathargs=(${pathPref[@]} 'projects' ${pathargs[${#pathargs[@]} - 2]} 'repos' "${pathargs[@]:${#pathargs[@]} - 1}")
   IFS='/' urlpath="${pathargs[*]}"
   providerBranchRef="/browse?at=$branch"
 elif [[ "${#pathargs[@]}" -ge '2' && ${pathargs[${#pathargs[@]} - 2]} == '_git' ]]; then

--- a/git-open
+++ b/git-open
@@ -130,12 +130,8 @@ elif [[ "${#pathargs[@]}" -ge 3 && ${pathargs[${#pathargs[@]} - 3]} == 'scm' ]];
   # Bitbucket server always has /scm/ as the third to last segment in the url path, e.g. /scm/ppp/test-repo.git
   # Anything before the 'scm' is part of the server's root context
 
-  # Check whether there are other context parts before the 'scm' part
-  pathPref=()
-  if [[ "${#pathargs[@]}" -gt 3 ]]; then
-    # If there are other context parts, add them, up to (but not including) the found 'scm'
-    pathPref=("${pathargs[*]:0:${#pathargs[@]} - 3}")
-  fi
+  # If there are other context parts, add them, up to (but not including) the found 'scm'
+  pathPref=("${pathargs[*]:0:${#pathargs[@]} - 3}")
 
   # Replace the 'scm' element, with 'projects'. Keep the first argument, the string 'repos', and finally the rest of the arguments.
   pathargs=(${pathPref[@]} 'projects' ${pathargs[${#pathargs[@]} - 2]} 'repos' "${pathargs[@]:${#pathargs[@]} - 1}")

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -214,22 +214,6 @@ setup() {
   refute_output --partial "@"
 }
 
-@test "bitbucket server" {
-  # https://github.com/paulirish/git-open/pull/15
-  git remote set-url origin "https://user@bitbucket.example.com/scm/ppp/test-repo.git"
-  run ../git-open
-  assert_output "https://bitbucket.example.com/projects/ppp/repos/test-repo"
-}
-
-@test "bitbucket server branch" {
-  # https://github.com/paulirish/git-open/pull/15
-  git remote set-url origin "https://user@bitbucket.example.com/scm/ppp/test-repo.git"
-  git checkout -B "bb-server"
-  run ../git-open
-  assert_output "https://bitbucket.example.com/projects/ppp/repos/test-repo/browse?at=bb-server"
-}
-
-
 @test "bitbucket: Bitbucket Server" {
   # https://github.com/paulirish/git-open/issues/77#issuecomment-309044010
   git remote set-url origin "https://user@mybb.domain.com/scm/ppp/rrr.git"
@@ -270,19 +254,23 @@ setup() {
 }
 
 
-@test "bitbucket server with different root context" {
+@test "bitbucket: Bitbucket Server with different root context" {
   # https://github.com/paulirish/git-open/pull/15
   git remote set-url origin "https://user@bitbucket.example.com/git/scm/ppp/test-repo.git"
   run ../git-open
-  assert_output "https://bitbucket.example.com/git/projects/ppp/repos/test-repo"
+  assert_output "https://bitbucket.example.com/git/projects/ppp/repos/test-repo" ||
+    assert_output "https://bitbucket.example.com/git/projects/ppp/repos/test-repo/?at=master" ||
+    assert_output "https://bitbucket.example.com/git/projects/ppp/repos/test-repo/?at=refs%2Fheads%2Fmaster"
 }
 
 
-@test "bitbucket server with different root context with multiple parts" {
+@test "bitbucket: Bitbucket Server with different root context with multiple parts" {
   # https://github.com/paulirish/git-open/pull/15
   git remote set-url origin "https://user@bitbucket.example.com/really/long/root/context/scm/ppp/test-repo.git"
   run ../git-open
-  assert_output "https://bitbucket.example.com/really/long/root/context/projects/ppp/repos/test-repo"
+  assert_output "https://bitbucket.example.com/really/long/root/context/projects/ppp/repos/test-repo" ||
+    assert_output "https://bitbucket.example.com/really/long/root/context/projects/ppp/repos/test-repo/?at=master" ||
+    assert_output "https://bitbucket.example.com/really/long/root/context/projects/ppp/repos/test-repo/?at=refs%2Fheads%2Fmaster"
 }
 
 
@@ -294,7 +282,6 @@ setup() {
   assert_output "https://mybb.domain.com/root/context/projects/~first.last/repos/rrr/browse?at=develop" ||
     assert_output "https://mybb.domain.com/root/context/projects/~first.last/repos/rrr/browse?at=refs%2Fheads%2Fdevelop" ||
     assert_output "https://mybb.domain.com/root/context/projects/~first.last/repos/rrr/browse?at=refs/heads/develop"
-
 }
 
 

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -269,6 +269,35 @@ setup() {
 
 }
 
+
+@test "bitbucket server with different root context" {
+  # https://github.com/paulirish/git-open/pull/15
+  git remote set-url origin "https://user@bitbucket.example.com/git/scm/ppp/test-repo.git"
+  run ../git-open
+  assert_output "https://bitbucket.example.com/git/projects/ppp/repos/test-repo"
+}
+
+
+@test "bitbucket server with different root context with multiple parts" {
+  # https://github.com/paulirish/git-open/pull/15
+  git remote set-url origin "https://user@bitbucket.example.com/really/long/root/context/scm/ppp/test-repo.git"
+  run ../git-open
+  assert_output "https://bitbucket.example.com/really/long/root/context/projects/ppp/repos/test-repo"
+}
+
+
+@test "bitbucket: Bitbucket Server private user repos with different root context" {
+  # https://github.com/paulirish/git-open/pull/83#issuecomment-309968538
+  git remote set-url origin "https://mybb.domain.com/root/context/scm/~first.last/rrr.git"
+  git checkout -B "develop"
+  run ../git-open
+  assert_output "https://mybb.domain.com/root/context/projects/~first.last/repos/rrr/browse?at=develop" ||
+    assert_output "https://mybb.domain.com/root/context/projects/~first.last/repos/rrr/browse?at=refs%2Fheads%2Fdevelop" ||
+    assert_output "https://mybb.domain.com/root/context/projects/~first.last/repos/rrr/browse?at=refs/heads/develop"
+
+}
+
+
 ##
 ## GitLab
 ##


### PR DESCRIPTION
I've finally found the time to take a look at the optional root context for self-hosted instances of Bitbucket Server. In our example, the Bitbucket server instance is not located at

https://bitbucket.example.com/scm/ppp/test-repo.git

but has an added `/git/` before the `scm` part:

https://bitbucket.example.com/git/scm/ppp/test-repo.git

We had discussed this a while back in https://github.com/paulirish/git-open/pull/83#issuecomment-309355515, but haven't had an implementation that took anything before the `scm` part into account.

I've refactored the Bitbucket logic to match the logic that was added for TFS, where the check for the `scm` part is now down from the back of the URL (the third to last item in the URL), instead of checking from the front.

No changes in the existing functionality, it just added support for self-hosted instances of Bitbucket Server that use an additional root context in the server deployment. Any optional path elements found before the `scm` match are now added to the final URL as part of the path transformation for Bitbucket Server. Please see the new unit tests for additional examples.