### PR TITLE
Fix bug with open -i on default VSTS project repo

### DIFF
--- a/git-open
+++ b/git-open
@@ -137,7 +137,8 @@ elif [[ "${#pathargs[@]}" -ge '2' && ${pathargs[${#pathargs[@]} - 2]} == '_git' 
   if (( is_issue )); then
     # Switch to workitems, provide work item id if specified
     urlpath="${urlpath%%/_git/*}/_workitems"
-    urlpath="${urlpath/_git\//}"
+    # Handle case for the default repository url
+    urlpath="${urlpath#_git\/*}"
     providerBranchRef="?id=${branch//[^0-9]/}"
   else
     # Keep project and repository name, append branch selector.

--- a/git-open
+++ b/git-open
@@ -137,6 +137,7 @@ elif [[ "${#pathargs[@]}" -ge '2' && ${pathargs[${#pathargs[@]} - 2]} == '_git' 
   if (( is_issue )); then
     # Switch to workitems, provide work item id if specified
     urlpath="${urlpath%%/_git/*}/_workitems"
+    urlpath="${urlpath/_git\//}"
     providerBranchRef="?id=${branch//[^0-9]/}"
   else
     # Keep project and repository name, append branch selector.

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -361,6 +361,13 @@ setup() {
   assert_output "http://tfs.example.com:8080/Project/Folder/_workitems?id=36"
 }
 
+@test "vsts: default project repository - issue" {
+  git remote set-url origin "https://gitopen.visualstudio.com/_git/Project"
+  git checkout -B "bugfix-36"
+  run ../git-open "--issue"
+  assert_output "https://gitopen.visualstudio.com/Project/_workitems?id=36"
+}
+
 
 teardown() {
   cd ..


### PR DESCRIPTION
The default VSTS clone url is different from other project repository urls

Default repository url: https://gitopen.visualstudio.com/_git/Project
Sibling repository url: https://gitopen.visualstudio.com/Project/_git/Repository

Trying to use git open -i on the default repository will lead to an
url formatted as https://gitopen.visualstudio.com/_git/Project/_workitems?id=xx
This url is malformed as the _git part should not be part of it.

This change will fix this bug and correctly format url as
https://gitopen.visualstudio.com/Project/_workitems?id=xx