### PR TITLE
Use ls-remote --get-url to get remote url

### DIFF
--- a/git-open
+++ b/git-open
@@ -49,8 +49,7 @@ remote=${1:-$default_remote}
 remote=${remote:-$tracked_remote}
 remote=${remote:-"origin"}
 
-# @TODO ls-remote will also expand "insteadOf" items `giturl=$(git ls-remote --get-url $remote)``
-giturl=$(git config --get "remote.${remote}.url")
+giturl=$(git ls-remote --get-url "$remote")
 
 if [[ -z "$giturl" ]]; then
   echo "Git remote is not set for $remote" 1>&2

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -36,6 +36,18 @@ setup() {
 }
 
 ##
+## url handling
+##
+
+@test "url: insteadOf handling" {
+	git config --global url.http://example.com/.insteadOf ex:
+	git remote set-url origin ex:example.git
+	git checkout -B master
+	run ../git-open
+	assert_output "http://example.com/example"
+}
+
+##
 ## GitHub
 ##
 


### PR DESCRIPTION
As noted in a comment, 'git ls-url --get-url' will expand insteadOf
mappings.  I use a number of shortcuts (like gh: for git on github,
lp: for git on launchpad, me: for my github repositories, etc), so I
was constantly hitting situations in which git-open would fail to do
the right thing.

It looks like '--get-url' has been available since git 2.12.0.

This has been bugging me for a while, but the fact that it was listed
in a comment in the script and not implemented makes me wonder if
there was in fact a reason for that.