### PR TITLE
Fixes markdownlint for build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node_modules/
 sandboxrepo
 git-open.1
-package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 sandboxrepo
 git-open.1
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -130,11 +130,12 @@ from which this plugin was forked.
 Please provide examples of the URLs you are parsing with each PR.
 
 You can run `git-open` in `echo` mode, which doesn't open your browser, but just prints the URL to stdout:
+
 ```sh
 env BROWSER='echo' ./git-open
 ```
 
-#### Testing:
+### Testing:
 
 You'll need to install [bats](https://github.com/sstephenson/bats#installing-bats-from-source), the Bash automated testing system. It's also available as `brew install bats`
 

--- a/git-open.1.md
+++ b/git-open.1.md
@@ -26,25 +26,25 @@ git hosting services are supported.
 ## EXAMPLES
 
 ```sh
-$ git open
+git open
 ```
 
 It opens https://github.com/TRACKED_REMOTE_USER/CURRENT_REPO/
 
 ```sh
-$ git open someremote
+git open someremote
 ```
 
 It opens https://github.com/PROVIDED_REMOTE_USER/CURRENT_REPO/
 
 ```sh
-$ git open someremote somebranch
+git open someremote somebranch
 ```
 
 It opens https://github.com/PROVIDED_REMOTE_USER/CURRENT_REPO/tree/PROVIDED_BRANCH
 
 ```sh
-$ git open --issue
+git open --issue
 ```
 
 If branches use naming convention of `issues/#123`, it opens
@@ -72,7 +72,7 @@ To configure git-open you may need to set some `git config` options.
 You can use `--global` to set across all repos, instead of just the current repo.
 
 ```sh
-$ git config [--global] option value
+git config [--global] option value
 ```
 
 ### Configuring which remote to open 
@@ -106,6 +106,7 @@ git config [--global] open.[gitdomain].protocol [value]
 ```
 
 **Example**
+
 - Your git remote is at `ssh://git@git.internal.biz:7000/XXX/YYY.git`
 - Your hosted gitlab is `http://repo.intranet/subpath/XXX/YYY`
 

--- a/markdownlint.json
+++ b/markdownlint.json
@@ -9,6 +9,7 @@
   "MD013": false,
   "MD026": false,
   "MD033": false,
+  "MD034": false,
   "MD036": false,
   "MD041": false
 }

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   "scripts": {
     "lint:editorconfig": "eclint check git-open* readme* .travis.yml",
     "lint:package": "pjv --recommendations --warnings",
-    "lint:readme": "node ./node_modules/markdownlint/lib/markdownlint.js --config markdownlint.json README.md",
-    "lint:man": "node ./node_modules/markdownlint/lib/markdownlint.js --config markdownlint.json git-open.1.md",
+    "lint:readme": "markdownlint --config markdownlint.json README.md",
+    "lint:man": "markdownlint --config markdownlint.json git-open.1.md",
     "man": "marked-man --version \"git-open $npm_package_version\" --manual \"Git manual\" --section 1 git-open.1.md > git-open.1",
     "test": "npm run unit && npm run lint:package && npm run lint:man && npm run lint:readme && npm run lint:editorconfig",
     "unit": "bats test/",
@@ -44,7 +44,7 @@
   "dependencies": {},
   "devDependencies": {
     "eclint": "^2.1.0",
-    "markdownlint": "^0.2.0",
+    "markdownlint-cli": "^0.7.1",
     "marked-man": "^0.2.1",
     "package-json-validator": "^0.6.1"
   }

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -40,7 +40,7 @@ setup() {
 ##
 
 @test "url: insteadOf handling" {
-	git config --global url.http://example.com/.insteadOf ex:
+	git config --local url.http://example.com/.insteadOf ex:
 	git remote set-url origin ex:example.git
 	git checkout -B master
 	run ../git-open


### PR DESCRIPTION
Markdownlint does not work currently, this will make it work.

**More detailed explanation:** We were calling `node markdownlint.js`, from the *markdownlint* package, which is meant to be used by other node scripts, and only exports js functions used to lint markdown. We should have been using the *markdownlint-cli package* (which is listed on the [official markdownlint listing](https://www.npmjs.com/package/markdownlint#related) as a related package) instead, which implements these functions and actually lints markdown as a cli.

Also fixes small bug in #115 affecting gitconfig

Closes #119 