### PR TITLE
Support opening current tag / commit

### DIFF
--- a/git-open
+++ b/git-open
@@ -153,8 +153,8 @@ function getConfig() {
 domain=$(getConfig "domain")
 protocol=$(getConfig "protocol")
 
-# Get current branch
-branch=${2:-$(git symbolic-ref -q --short HEAD)}
+# Get current branch / tag / commit
+branch=${2:-$(git symbolic-ref -q --short HEAD || git describe --tags --exact-match 2>/dev/null || git rev-parse HEAD)}
 
 # Split arguments on '/'
 IFS='/' read -r -a pathargs <<<"$urlpath"

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -65,6 +65,17 @@ setup() {
   assert_output "https://github.com/user/repo/tree/mybranch"
 }
 
+@test "gh: tag" {
+  git remote set-url origin "git@github.com:user/repo.git"
+  git tag mytag
+  echo a > a
+  git add a
+  git commit -m a
+  git checkout mytag
+  run ../git-open
+  assert_output "https://github.com/user/repo/tree/mytag"
+}
+
 @test "gh: non-origin remote" {
   git remote set-url origin "git@github.com:user/repo.git"
   git remote add upstream "git@github.com:upstreamorg/repo.git"
@@ -290,6 +301,17 @@ setup() {
   git remote set-url origin "git@bitbucket.org:paulirish/crbug-extension.git"
   run ../git-open
   assert_output --partial "https://bitbucket.org/paulirish/crbug-extension"
+}
+
+@test "bitbucket: tag" {
+  git remote set-url origin "git@bitbucket.org:paulirish/crbug-extension.git"
+  git tag mytag
+  echo a > a
+  git add a
+  git commit -m a
+  git checkout mytag
+  run ../git-open
+  assert_output "https://bitbucket.org/paulirish/crbug-extension/src?at=mytag"
 }
 
 @test "bitbucket: non-origin remote" {


### PR DESCRIPTION
Fixes #89.
Fixes #129.

Examples:
- https://bitbucket.org/mirror/linux/src?at=v4.19-rc2
- https://github.com/paulirish/git-open/tree/1.1.1
- https://gitlab.freedesktop.org/xorg/lib/libx11/tree/libX11-1.6.6