### PR TITLE
Remove openopt, allow spaces in $BROWSER 

### DIFF
--- a/git-open
+++ b/git-open
@@ -235,21 +235,16 @@ case $( uname -s ) in
   CYGWIN*)  open='cygstart';;
   *)        # Try to detect WSL (Windows Subsystem for Linux)
             if uname -r | grep -q Microsoft; then
-              open='powershell.exe'
-              openopt='Start'
+              open='powershell.exe Start'
             else
               open='xdg-open'
             fi;;
 esac
 
 # Allow printing the url if BROWSER=echo
-if [[ $BROWSER == "echo" ]]; then
-  openopt=''
-else
+if [[ $BROWSER != "echo" ]]; then
   exec &>/dev/null
 fi
 
 # open it in a browser
-${BROWSER:-$open} $openopt "$openurl"
-
-unset openopt
+${BROWSER:-$open} "$openurl"


### PR DESCRIPTION
Remove the openopt variable, instead opting to allow spaces in `$BROWSER`.

`$BROWSER` as used by the XDG implementation allows spaces (and `%s`
printf-style formatting strings), and is actually a PATH-style list.
While this patch doesn't make git-open compliant with the XDG-style
variable, it does allow for the use of `BROWSER="powershell.exe
Start"` in the environment.