### PR TITLE
Fix shellcheck on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,5 @@
 language: node_js
 node_js: "node"
-addons:
-  apt:
-    sources:
-    - debian-sid    # Grab ShellCheck from the Debian repo
-    packages:
-    - shellcheck
 cache:
   directories:
     - node_modules


### PR DESCRIPTION
Apparently doesn't need to be installed any longer: https://github.com/koalaman/shellcheck/pull/1121