### PR TITLE
Add a --commit option

### DIFF
--- a/git-open
+++ b/git-open
@@ -16,6 +16,7 @@ git open [remote] [branch]
   https://github.com/paulirish/git-open/
 
   Available options are
+c,commit!     open current commit
 i,issue!      open issues page
 p,print!      just print the url
 "
@@ -25,12 +26,14 @@ p,print!      just print the url
 SUBDIRECTORY_OK='Yes' . "$(git --exec-path)/git-sh-setup"
 
 # Defaults
+is_commit=0
 is_issue=0
 protocol="https"
 print_only=0
 
 while test $# != 0; do
   case "$1" in
+  --commit) is_commit=1;;
   --issue) is_issue=1;;
   --print) print_only=1;;
   --) shift; break ;;
@@ -227,8 +230,11 @@ fi
 
 openurl="$protocol://$domain/$urlpath"
 
-# simplify URL for master
-if [[ $remote_ref != "master" ]]; then
+if (( is_commit )); then
+    sha=$(git rev-parse HEAD)
+    openurl="$openurl/commit/$sha"
+elif [[ $remote_ref != "master" ]]; then
+    # simplify URL for master
     openurl="$openurl$providerBranchRef"
 fi
 

--- a/git-open.1.md
+++ b/git-open.1.md
@@ -3,7 +3,7 @@
 
 ## SYNOPSIS
 
-`git open` [--issue] [remote-name] [branch-name]
+`git open` [--issue] [--commit] [remote-name] [branch-name]
 
 
 ## DESCRIPTION
@@ -13,6 +13,10 @@ git hosting services are supported.
 
 
 ## OPTIONS
+
+`-c`, `--commit`
+  Open the current commit. See `EXAMPLES` for more information. 
+  Only tested with GitHub & GitLab.
 
 `-i`, `--issue`
   Open the current issue. When the name of the current branch matches the right pattern, 
@@ -57,6 +61,14 @@ git open --print
 ```
 
 It prints the URL https://github.com/TRACKED_REMOTE_USER/CURRENT_REPO/
+
+```sh
+git open --commit
+```
+
+Supposing that the current sha is `2ddc8d4548d0cee3d714dcf0068dbec5b168a9b2`, it opens
+https://github.com/TRACKED_REMOTE_USER/CURRENT_REPO/commit/2ddc8d4548d0cee3d714dcf0068dbec5b168a9b2
+
 
 ## SUPPORTED GIT HOSTING SERVICES
 

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -160,6 +160,13 @@ setup() {
   assert_output "https://github.com/paulirish/git-open/issues/38"
 }
 
+@test "gh: git open --commit" {
+  git remote set-url origin "github.com:paulirish/git-open.git"
+  sha=$(git rev-parse HEAD)
+  run ../git-open "--commit"
+  assert_output "https://github.com/paulirish/git-open/commit/${sha}"
+}
+
 @test "gh: gist" {
   git remote set-url origin "git@gist.github.com:2d84a6db1b41b4020685.git"
   run ../git-open


### PR DESCRIPTION
This adds a `--commit` option that opens the current commit in the browser.

I've only tested this with gitlab seeing as I needed it there. If this could be useful I can integrate any feedback you might have to get this proposal merged.