### PR TITLE
Implement single letter option flags

### DIFF
--- a/git-open
+++ b/git-open
@@ -33,9 +33,9 @@ print_only=0
 
 while test $# != 0; do
   case "$1" in
-  --commit) is_commit=1;;
-  --issue) is_issue=1;;
-  --print) print_only=1;;
+  --commit|-c) is_commit=1;;
+  --issue|-i) is_issue=1;;
+  --print|-p) print_only=1;;
   --) shift; break ;;
   esac
   shift


### PR DESCRIPTION
The documentation claims that single letter flags -c, -i and -p should work - but on my GNU bash, version 5.0.2(1)-release (x86_64-apple-darwin16.7.0), they do not, because they do not seem to be implemented.

I have only tested this branch on this one machine but the change seems fairly clear...