### PR TITLE
Remove unused code and fix double-negation

### DIFF
--- a/git-open
+++ b/git-open
@@ -256,10 +256,5 @@ if (( print_only )); then
   BROWSER="echo"
 fi
 
-# Allow printing the url if BROWSER=echo
-if [[ $BROWSER != "echo" ]]; then
-  exec &>/dev/null
-fi
-
 # open it in a browser
 ${BROWSER:-$open} "$openurl"

--- a/git-open
+++ b/git-open
@@ -136,7 +136,7 @@ else
   # Resolve sshconfig aliases
   if [[ -e "$ssh_config" ]]; then
     domain_resolv=$(ssh_resolve "$domain")
-    if [[ ! -z "$domain_resolv" ]]; then
+    if [[ -n "$domain_resolv" ]]; then
       domain="$domain_resolv"
     fi
   fi


### PR DESCRIPTION
Co-authored-by: Jayashree <jayashree.kammu@gmail.com>

We are using your tool for a long period of time. We are **interested to contribute** to the tool. While we are going through the code we think we found an unused code.

`exec &>/dev/null` - we are redirecting the outstream and errstream to `null` but we are not printing anything after this line. So we think we can remove this line. What do you think?