### PR TITLE
allow for git commit hashes to be passed to git open --commit command

### DIFF
--- a/git-open
+++ b/git-open
@@ -35,7 +35,10 @@ suffix_flag=""
 
 while test $# != 0; do
   case "$1" in
-  --commit) is_commit=1;;
+  -c|--commit)
+      is_commit="$1"
+      commit_hash="$3"
+      shift ;;
   --issue) is_issue=1;;
   --suffix=*) suffix_flag="$1";;
   --print) print_only=1;;
@@ -237,7 +240,9 @@ fi
 
 openurl="$protocol://$domain/$urlpath"
 
-if (( is_commit )); then
+if [ "$commit_hash" ]; then
+    openurl="$openurl/commit/$commit_hash"
+elif (( is_commit )); then
     sha=$(git rev-parse HEAD)
     openurl="$openurl/commit/$sha"
 elif [[ $remote_ref != "master" ]]; then

--- a/git-open.1.md
+++ b/git-open.1.md
@@ -3,7 +3,7 @@
 
 ## SYNOPSIS
 
-`git open` [--issue] [--commit] [--suffix some_suffix] [remote-name] [branch-name]
+`git open` [--issue] [--commit some_commit_hash] [--suffix some_suffix] [remote-name] [branch-name]
 
 
 ## DESCRIPTION
@@ -15,7 +15,7 @@ git hosting services are supported.
 ## OPTIONS
 
 `-c`, `--commit`
-  Open the current commit. See `EXAMPLES` for more information. 
+  Open the current commit or the given commit hash. See `EXAMPLES` for more information. 
   Only tested with GitHub & GitLab.
 
 `-i`, `--issue`
@@ -78,6 +78,11 @@ git open --commit
 Supposing that the current sha is `2ddc8d4548d0cee3d714dcf0068dbec5b168a9b2`, it opens
 https://github.com/TRACKED_REMOTE_USER/CURRENT_REPO/commit/2ddc8d4548d0cee3d714dcf0068dbec5b168a9b2
 
+```sh
+git open --commit somecommithash
+```
+
+It opens https://github.com/TRACKED_REMOTE_USER/CURRENT_REPO/commit/somecommithash
 
 ## SUPPORTED GIT HOSTING SERVICES
 

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -167,6 +167,11 @@ setup() {
   assert_output "https://github.com/paulirish/git-open/commit/${sha}"
 }
 
+@test "gh: git open --commit somecommithash" {
+  run ../git-open "--commit" "somecommithash"
+  assert_output "https://github.com/paulirish/git-open/commit/somecommithash"
+}
+
 @test "gh: git open --suffix anySuffix" {
   run ../git-open "--suffix" "anySuffix"
   assert_output "https://github.com/paulirish/git-open/anySuffix"


### PR DESCRIPTION
build on top of the work done in #125 , allowing commit hashes to be passed as a specific commit instead of the current commit.