### PR TITLE
Readme: Fix Folder Permission For Oh-My-Zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ for testing before adding it to your `.zshrc`.
 #### [Oh-My-Zsh](http://ohmyz.sh/)
 
 1. `git clone https://github.com/paulirish/git-open.git $ZSH_CUSTOM/plugins/git-open`
-1. Add `git-open` to your plugin list - edit `~/.zshrc` and change
+2. `sudo chmod -R 755 $ZSH_CUSTOM/plugins/git-open`
+3. Add `git-open` to your plugin list - edit `~/.zshrc` and change
    `plugins=(...)` to `plugins=(... git-open)`
 
 #### [Zgen](https://github.com/tarjoilija/zgen)


### PR DESCRIPTION
When installing for Oh-My-Zsh, I ran into an error regarding me not being able to open the directory after sourcing my .zshrc. Specifically:

```
[oh-my-zsh] Insecure completion-dependent directories detected:
drwxrwxrwx 1 alan alan 512 Apr  1 10:59 /home/alan/.oh-my-zsh/custom/plugins/git-open

[oh-my-zsh] For safety, we will not load completions from these directories until
[oh-my-zsh] you fix their permissions and ownership and restart zsh.
[oh-my-zsh] See the above list for directories with group or other writability.

[oh-my-zsh] To fix your permissions you can do so by disabling
[oh-my-zsh] the write permission of "group" and "others" and making sure that the[oh-my-zsh] owner of these directories is either root or your current user.
[oh-my-zsh] The following command may help:
[oh-my-zsh]     compaudit | xargs chmod g-w,o-w
[oh-my-zsh] If the above didn't help or you want to skip the verification of
[oh-my-zsh] insecure directories you can set the variable ZSH_DISABLE_COMPFIX to
[oh-my-zsh] "true" before oh-my-zsh is sourced in your zshrc file.

zsh compinit: insecure directories, run compaudit for list.
```

Following https://github.com/zsh-users/zsh-completions/issues/433, if you chmod the directory then it seems to work without issue.