### PR TITLE
Fix for bitbucket

### DIFF
--- a/git-open
+++ b/git-open
@@ -186,7 +186,7 @@ fi
 
 if [[ "$domain" == 'bitbucket.org' ]]; then
   # Bitbucket, see https://github.com/paulirish/git-open/issues/80 for why ?at is needed.
-  providerBranchRef="/src?at=$remote_ref"
+  providerBranchRef="/branch/$remote_ref"
 elif [[ "${#pathargs[@]}" -ge 3 && ${pathargs[${#pathargs[@]} - 3]} == 'scm' ]]; then
   # Bitbucket server always has /scm/ as the third to last segment in the url path, e.g. /scm/ppp/test-repo.git
   # Anything before the 'scm' is part of the server's root context


### PR DESCRIPTION
Currently the command git open is not working with bitbucket. It opens master branch instead of current branch.
That's because src?at= is not supported any more. 
The correct way is /branch/${branch_name}

I tested this fix locally and it works fine