### PR TITLE
Fix suffix with `=` in it

### DIFF
--- a/git-open
+++ b/git-open
@@ -46,7 +46,8 @@ done
 
 # parse suffix from suffix=value
 IFS='=' read -ra suffix_flag <<< "$suffix_flag"
-suffix=${suffix_flag[1]}
+function join_by { local IFS="$1"; shift; echo "$*"; }
+suffix=$(join_by = ${suffix_flag[@]:1})
 
 # are we in a git repo?
 if ! git rev-parse --is-inside-work-tree &>/dev/null; then

--- a/git-open
+++ b/git-open
@@ -47,7 +47,7 @@ done
 # parse suffix from suffix=value
 IFS='=' read -ra suffix_flag <<< "$suffix_flag"
 function join_by { local IFS="$1"; shift; echo "$*"; }
-suffix=$(join_by = ${suffix_flag[@]:1})
+suffix=$(join_by "=" "${suffix_flag[@]:1}")
 
 # are we in a git repo?
 if ! git rev-parse --is-inside-work-tree &>/dev/null; then

--- a/git-open
+++ b/git-open
@@ -144,7 +144,7 @@ else
   # Resolve sshconfig aliases
   if [[ -e "$ssh_config" ]]; then
     domain_resolv=$(ssh_resolve "$domain")
-    if [[ ! -z "$domain_resolv" ]]; then
+    if [[ -n "$domain_resolv" ]]; then
       domain="$domain_resolv"
     fi
   fi

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -172,6 +172,11 @@ setup() {
   assert_output "https://github.com/paulirish/git-open/anySuffix"
 }
 
+@test "gh: git open --suffix anySuffix?hello=world" {
+  run ../git-open "--suffix" "anySuffix?hello=world"
+  assert_output "https://github.com/paulirish/git-open/anySuffix?hello=world"
+}
+
 @test "gh: gist" {
   git remote set-url origin "git@gist.github.com:2d84a6db1b41b4020685.git"
   run ../git-open


### PR DESCRIPTION
Hi!

Thanks for this very useful tool, I use it daily!

I've noticed that cases where the `--suffix` value contains `=` signs were incorrectly handled.

For example, when in this repo:
```
$ git open -p --suffix="anySuffix?hello=world"
https://github.com/paulirish/git-open/anySuffix?hello

# we would expect https://github.com/paulirish/git-open/anySuffix?hello=world instead
```

This is due to how the parsing of the `--suffix` value is parsed. The `--suffix=value` is split by `=`, and then the element 1 of the array is taken (which leaves out anything that comes after an `=` sign in `value`):
https://github.com/paulirish/git-open/blob/d9a0d19ce291ab09d182e389edaa278bb2febb11/git-open#L48-L49

I've changed that by taking all elements of the array from 1 until the end, and then joining the array by `=`.