### PR TITLE
Fix opening browser on wsl2

### DIFF
--- a/git-open
+++ b/git-open
@@ -273,4 +273,4 @@ if [[ $BROWSER != "echo" ]]; then
 fi
 
 # open it in a browser
-${BROWSER:-$open} "$openurl"
+"${BROWSER:-$open}" "$openurl"


### PR DESCRIPTION
Hi!

I'm trying to use this on my Windows10 with WSL2, when browser directory is on Windows, normally it should be something like this `/mnt/c/Program Files (x86)/Google/Chrome/Application/chrome.exe`.

If a user has set `$BROWSER` to this, it cannot open browser automatically.
It seems like when `${BROWSER:-$open}` invoked it cannot handle the spaces in `$BROWSER`

So adding double quotes around it would simply solve it.

I'm not very familiar with shell script. And I've tested on my local machine and they all passed. Hope this will help. 😂

