### PR TITLE
Replace dirname with zsh expansion modifier

### DIFF
--- a/git-open.plugin.zsh
+++ b/git-open.plugin.zsh
@@ -3,4 +3,4 @@
 # Make git-open easy to install and keep up to date if you're using a
 # ZSH framework like Zgen or Antigen
 
-  export PATH=$(dirname $0):${PATH}
+export PATH=${0:A:h}:${PATH}


### PR DESCRIPTION
- [x] No leading whitespace
- [x] No external command
- [x] More cryptic

Basically, these are modifiers to parameter expansion. The parameter here is `$0`, the `:A` modifier converts it into an absolute path resolving symbolic links in the process, the `:h` modifier takes 'head'  by stripping 'tail', i.e. removes last path component.

Read more about built-in zsh expansions and substitutions at zsh documentation website: http://zsh.sourceforge.net/Doc/Release/Expansion.html#Parameter-Expansion