### PR TITLE
gitlab: fix issue ID parsing

### DIFF
--- a/git-open
+++ b/git-open
@@ -177,7 +177,8 @@ IFS='/' read -r -a pathargs <<<"$urlpath"
 
 if (( is_issue )); then
   # For issues, take the numbers and preprend 'issues/'
-  providerBranchRef="/issues/${remote_ref//[^0-9]/}"
+  [[ $remote_ref =~ [0-9]+ ]]
+  providerBranchRef="/issues/${BASH_REMATCH[0]}"
 else
   # Make # and % characters url friendly
   #   github.com/paulirish/git-open/pull/24

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -522,6 +522,13 @@ setup() {
   assert_output "https://git.example.com:7000/XXX/YYY"
 }
 
+@test "gitlab: issue" {
+  git remote set-url origin "git@gitlab.example.com:user/repo"
+  git checkout -B "10-bump-up-to-v2.0"
+  run ../git-open "--issue"
+  assert_output "https://gitlab.example.com/user/repo/issues/10"
+}
+
 ##
 ## Visual Studio Team Services
 ##


### PR DESCRIPTION
fixes #182

Hi,

I use this good tool everyday and thank you!

In GitLab, the branch's name is normally the issue ID followed by the hyphenated title,
and I've noticed that the issue's titile having numbers is incorrectly handled.

```sh
$ git branch
* 10-bump-up-to-v2.0
  main
$ git open -ip
https://gitlab.example.com/user/repo/issues/1020
# I expected https://gitlab.example.com/user/repo/issues/10
```

I've fixed the issue ID parsing to take the first number in branch name.
