### PR TITLE
Add Fig as an installation method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ or copy `git-open` into an existing included path like `/usr/local/bin`).
 ```sh
 npm install --global git-open
 ```
+### Fig
+
+Install `git-open` with [Fig](https://fig.io) with one click.
+
+<a href="https://fig.io/plugins/other/git-open" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
 
 ### Windows Powershell
 


### PR DESCRIPTION
We recently listed <plugin name> on [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig listed as a download method on your readme. Thanks so much and please let me know if you have any questions!

