### PR TITLE
Do not load PowerShell profile

### DIFF
--- a/git-open
+++ b/git-open
@@ -257,7 +257,7 @@ case $( uname -s ) in
   CYGWIN*)  open='cygstart';;
   *)        # Try to detect WSL (Windows Subsystem for Linux)
             if uname -r | grep -q -i Microsoft; then
-              open='powershell.exe Start'
+              open='powershell.exe -NoProfile Start'
             else
               open='xdg-open'
             fi;;


### PR DESCRIPTION
This allows `git-open` to finish executing faster on WSL.