### PR TITLE
Add option to ignore the currently checked out branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Please provide examples of the URLs you are parsing with each PR.
 
 ### Testing:
 
-You'll need to install [bats](https://github.com/sstephenson/bats#installing-bats-from-source), the Bash automated testing system. It's also available as `brew install bats`
+You'll need to install [bats](https://github.com/bats-core/bats-core), the Bash automated testing system. It's also available as `brew install bats-core`
 
 ```sh
 git submodule update --init # pull in the assertion libraries

--- a/git-open
+++ b/git-open
@@ -241,8 +241,8 @@ openurl="$protocol://$domain/$urlpath"
 if (( is_commit )); then
     sha=$(git rev-parse HEAD)
     openurl="$openurl/commit/$sha"
-elif [[ $remote_ref != "master" ]]; then
-    # simplify URL for master
+elif [[ $remote_ref != "master" && $remote_ref != "main" ]]; then
+    # simplify URL for master and main
     openurl="$openurl$providerBranchRef"
 fi
 

--- a/git-open
+++ b/git-open
@@ -16,11 +16,11 @@ git open [remote] [branch]
   https://github.com/paulirish/git-open/
 
   Available options are
-c,commit!           open current commit
-i,issue!            open issues page
-s,suffix=           append this suffix
-p,print!            just print the url
-d,default-branch!   open the repo as if you were in the default branch (master/main)
+c,commit!         open current commit
+i,issue!          open issues page
+s,suffix=         append this suffix
+p,print!          just print the url
+b,ignore-branch!  just open the repo regardless of the currently checked out branch
 "
 
 # https://github.com/koalaman/shellcheck/wiki/SC1090
@@ -33,7 +33,7 @@ is_issue=0
 protocol="https"
 print_only=0
 suffix_flag=""
-use_default_branch=0
+ignore_branch=0
 
 while test $# != 0; do
   case "$1" in
@@ -41,7 +41,7 @@ while test $# != 0; do
   --issue) is_issue=1;;
   --suffix=*) suffix_flag="$1";;
   --print) print_only=1;;
-  --default-branch) use_default_branch=1;;
+  --ignore-branch) ignore_branch=1;;
   --) shift; break ;;
   esac
   shift
@@ -244,7 +244,7 @@ openurl="$protocol://$domain/$urlpath"
 if (( is_commit )); then
     sha=$(git rev-parse HEAD)
     openurl="$openurl/commit/$sha"
-elif [[ $remote_ref != "master" && $remote_ref != "main" && $use_default_branch != 1 ]]; then
+elif [[ $remote_ref != "master" && $remote_ref != "main" && $ignore_branch != 1 ]]; then
     # simplify URL for master and main
     openurl="$openurl$providerBranchRef"
 fi

--- a/git-open
+++ b/git-open
@@ -16,10 +16,11 @@ git open [remote] [branch]
   https://github.com/paulirish/git-open/
 
   Available options are
-c,commit!     open current commit
-i,issue!      open issues page
-s,suffix=     append this suffix
-p,print!      just print the url
+c,commit!           open current commit
+i,issue!            open issues page
+s,suffix=           append this suffix
+p,print!            just print the url
+d,default-branch!   open the repo as if you were in the default branch (master/main)
 "
 
 # https://github.com/koalaman/shellcheck/wiki/SC1090
@@ -32,6 +33,7 @@ is_issue=0
 protocol="https"
 print_only=0
 suffix_flag=""
+use_default_branch=0
 
 while test $# != 0; do
   case "$1" in
@@ -39,6 +41,7 @@ while test $# != 0; do
   --issue) is_issue=1;;
   --suffix=*) suffix_flag="$1";;
   --print) print_only=1;;
+  --default-branch) use_default_branch=1;;
   --) shift; break ;;
   esac
   shift
@@ -241,7 +244,7 @@ openurl="$protocol://$domain/$urlpath"
 if (( is_commit )); then
     sha=$(git rev-parse HEAD)
     openurl="$openurl/commit/$sha"
-elif [[ $remote_ref != "master" && $remote_ref != "main" ]]; then
+elif [[ $remote_ref != "master" && $remote_ref != "main" && $use_default_branch != 1 ]]; then
     # simplify URL for master and main
     openurl="$openurl$providerBranchRef"
 fi

--- a/git-open.1.md
+++ b/git-open.1.md
@@ -23,8 +23,8 @@ git hosting services are supported.
   it will open the webpage with that issue. See `EXAMPLES` for more information. 
   This only works on GitHub, GitLab, Visual Studio Team Services and Team Foundation Server at the moment.
 
-`-d`, `--default-branch`
-  Open the repository as if you were in the default branch (`master`/`main`)
+`-b`, `--ignore-branch`
+  Just open the repository regardless of the currently checked out branch
 
 `-s`, `--suffix` some_suffix
   Append the given suffix to the url
@@ -64,10 +64,10 @@ https://github.com/TRACKED_REMOTE_USER/CURRENT_REPO/issues/123
 
 
 ```sh
-git open --default-branch
+git open --ignore-branch
 ```
 
-It won't suffix the url with `/tree/CURRENT_BRANCH` even if you aren't currently on `master` or `main` branch, it opens https://github.com/TRACKED_REMOTE_USER/CURRENT_REPO/
+It won't suffix the url with `/tree/CURRENT_BRANCH` regardless of the currently checked out branch, it opens https://github.com/TRACKED_REMOTE_USER/CURRENT_REPO/
 
 ```sh
 git open --suffix pulls

--- a/git-open.1.md
+++ b/git-open.1.md
@@ -23,6 +23,9 @@ git hosting services are supported.
   it will open the webpage with that issue. See `EXAMPLES` for more information. 
   This only works on GitHub, GitLab, Visual Studio Team Services and Team Foundation Server at the moment.
 
+`-d`, `--default-branch`
+  Open the repository as if you were in the default branch (`master`/`main`)
+
 `-s`, `--suffix` some_suffix
   Append the given suffix to the url
 
@@ -58,6 +61,13 @@ git open --issue
 
 If branches use naming convention of `issues/#123`, it opens
 https://github.com/TRACKED_REMOTE_USER/CURRENT_REPO/issues/123
+
+
+```sh
+git open --default-branch
+```
+
+It won't suffix the url with `/tree/CURRENT_BRANCH` even if you aren't currently on `master` or `main` branch, it opens https://github.com/TRACKED_REMOTE_USER/CURRENT_REPO/
 
 ```sh
 git open --suffix pulls

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -70,7 +70,7 @@ setup() {
 	git config --local url.http://example.com/.insteadOf ex:
 	git remote set-url origin ex:example.git
 	git checkout -B development
-	run ../git-open -d
+	run ../git-open -b
 	assert_output "http://example.com/example"
 }
 
@@ -78,7 +78,7 @@ setup() {
 	git config --local url.http://example.com/.insteadOf ex:
 	git remote set-url origin ex:example.git
 	git checkout -B development
-	run ../git-open -d -s actions
+	run ../git-open -b -s actions
 	assert_output "http://example.com/example/actions"
 }
 

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -66,6 +66,22 @@ setup() {
 	assert_output "http://example.com/example"
 }
 
+@test "url: use default branch" {
+	git config --local url.http://example.com/.insteadOf ex:
+	git remote set-url origin ex:example.git
+	git checkout -B development
+	run ../git-open -d
+	assert_output "http://example.com/example"
+}
+
+@test "url: use-default with suffix" {
+	git config --local url.http://example.com/.insteadOf ex:
+	git remote set-url origin ex:example.git
+	git checkout -B development
+	run ../git-open -d -s actions
+	assert_output "http://example.com/example/actions"
+}
+
 ##
 ## GitHub
 ##

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -58,6 +58,14 @@ setup() {
 	assert_output "http://example.com/example"
 }
 
+@test "url: simplification" {
+	git config --local url.http://example.com/.insteadOf ex:
+	git remote set-url origin ex:example.git
+	git checkout -B main
+	run ../git-open
+	assert_output "http://example.com/example"
+}
+
 ##
 ## GitHub
 ##


### PR DESCRIPTION
- The `--ignore-branch` flag will forced the URL to be `/TRACKED_REMOTE_USER/CURRENT_REPO/` without the `/tree/CURRENT_BRANCH` suffix that appears when default branch is not checked out.
- Add `main` as an alternative default branch name in-addition of `master`.
- Update `bats` to the forked `bats-core` as the original repository is no longer maintained.