### PR TITLE
Use absolute PATH to powershell.exe

### DIFF
--- a/git-open
+++ b/git-open
@@ -263,7 +263,7 @@ case $( uname -s ) in
   CYGWIN*)  open='cygstart';;
   *)        # Try to detect WSL (Windows Subsystem for Linux)
             if uname -r | grep -q -i Microsoft; then
-              open='powershell.exe -NoProfile Start'
+              open='/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe -NoProfile Start'
             else
               open='xdg-open'
             fi;;


### PR DESCRIPTION
This is guaranteed to be always at this location and is always available if Interopt is enabled.

With this it is no longer required to have powershell.exe in PATH which significantly slows down tab completion due to the very slow fs access times on WSL2. Before git-open would silently fail if powershell.exe was not available.