### PR TITLE
Add oh-my-bash support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ start zsh, and periodically checking for updates to the git repository. You can
 also add the plugin to a running zsh with `antigen bundle paulirish/git-open`
 for testing before adding it to your `.zshrc`.
 
+#### [Oh-My-Bash](https://github.com/ohmybash/oh-my-bash)
+
+1. `git clone https://github.com/paulirish/git-open.git $OSH_CUSTOM/plugins/git-open`
+2. Add `git-open` to your plugin list - edit `~/.bashrc` and change
+    `plugins=(...)` to `plugins=(... git-open)`
+3. `source ~/.bashrc`
+
 #### [Oh-My-Zsh](http://ohmyz.sh/)
 
 1. `git clone https://github.com/paulirish/git-open.git $ZSH_CUSTOM/plugins/git-open`

--- a/git-open.plugin.sh
+++ b/git-open.plugin.sh
@@ -1,0 +1,6 @@
+# This plugin is MIT licensed to match the git-open license.
+#
+# Make git-open easy to install and keep up to date if you're using a
+# Bash framework like oh-my-bash.
+
+export PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )":${PATH}


### PR DESCRIPTION
This adds support for loading git-open via [oh-my-bash](https://github.com/ohmybash/oh-my-bash). Similar to the oh-my-zsh installation method.