### PR TITLE
fix: Handle browser paths with spaces correctly

### DIFF
--- a/git-open
+++ b/git-open
@@ -298,4 +298,4 @@ if (( print_only )); then
 fi
 
 # open it in a browser
-${BROWSER:-$open} "$openurl"
+"${BROWSER:-$open}" "$openurl"


### PR DESCRIPTION
Resolves an issue where browser paths containing spaces in the BROWSER environment variable (e.g., '/mnt/c/Program Files/Mozilla Firefox/firefox.exe') were causing "No such file or directory" errors on WSL environments.

The fix properly quotes the path when executing the browser command, ensuring compatibility with Windows applications accessed through WSL.

Tested on Ubuntu 24.04 WSL with Windows Firefox installation.

![image](https://github.com/user-attachments/assets/861b66f3-7844-4690-9240-505bad0df357)

![image](https://github.com/user-attachments/assets/72c4a198-1aca-4646-84f8-b61197d99aaa)
