### PR TITLE
Support specifying commit hash with -c option

### DIFF
--- a/git-open
+++ b/git-open
@@ -16,7 +16,7 @@ git open [remote] [branch]
   https://github.com/paulirish/git-open/
 
   Available options are
-c,commit!     open current commit
+c,commit=     open current commit
 i,issue!      open issues page
 s,suffix=     append this suffix
 f,file=       append this file
@@ -34,10 +34,11 @@ protocol="https"
 print_only=0
 suffix_flag=""
 file_flag=""
+commit_hash=""
 
 while test $# != 0; do
   case "$1" in
-  --commit) is_commit=1;;
+  --commit=*)  is_commit=1;commit_hash="$1";;
   --issue) is_issue=1;;
   --suffix=*) suffix_flag="$1";;
   --file=*) file_flag="$1";;
@@ -259,7 +260,7 @@ fi
 openurl="$protocol://$domain/$urlpath"
 
 if (( is_commit )); then
-    sha=$(git rev-parse HEAD)
+ sha="${commit_hash:-$(git rev-parse HEAD)}"
     openurl="$openurl/commit/$sha"
 elif [[ $remote_ref != "master" || "$file" ]]; then
     # simplify URL for master


### PR DESCRIPTION
Allow users to pass a specific commit hash with the -c option instead of always using HEAD.

Changes:
- Modified the option spec to accept a value with -c option (c,commit=)
- Added commit_hash variable to store the provided commit hash
- Updated option parsing to capture the commit hash argument
- Updated commit URL generation to use provided hash or fallback to HEAD

Usage:
  git open -c <commit-hash>  # Open specific commit
  git open -c                 # Open current commit (HEAD)