### PR TITLE
tests: add test for open.default.remote configuration

### DIFF
--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -248,6 +248,14 @@ setup() {
   assert_output "http://github.com/user/repo"
 }
 
+@test "basic: open.default.remote configuration" {
+  git remote set-url origin "git@github.com:paulirish/git-open.git"
+  git remote add upstream "git@github.com:upstreamorg/repo.git"
+  git config --local open.default.remote upstream
+  run ../git-open
+  assert_output "https://github.com/upstreamorg/repo"
+}
+
 ##
 ## SSH config
 ##


### PR DESCRIPTION
This PR adds a test case to ensure that the open.default.remote configuration is correctly respected, as requested in #106.

The test verifies that when multiple remotes exist and a default is specified in the git config, `git-open` prioritizes that remote over the tracked branch remote or the default `origin`.

Fixes #106

---
**Original Prompt:**
> "Can you find paul irish's GitHub and find an open issue and write a pull request and send it.. make sure it is high quality"