### PR TITLE
feat: add URL-based browser configuration

### DIFF
--- a/git-open
+++ b/git-open
@@ -301,4 +301,4 @@ if (( print_only )); then
 fi
 
 # open it in a browser
-${BROWSER:-${browser:-$open}} "$openurl"
+eval "${BROWSER:-${browser:-$open}}" \"\$openurl\"

--- a/git-open
+++ b/git-open
@@ -279,6 +279,9 @@ if [ "$suffix" ]; then
     openurl="$openurl/$suffix"
 fi
 
+# get browser from git config, with URL-specific matching
+browser=$(getConfig "browser")
+
 # get current open browser command
 case $( uname -s ) in
   Darwin)   open='open';;
@@ -298,4 +301,4 @@ if (( print_only )); then
 fi
 
 # open it in a browser
-${BROWSER:-$open} "$openurl"
+${BROWSER:-${browser:-$open}} "$openurl"

--- a/git-open.1.md
+++ b/git-open.1.md
@@ -158,6 +158,34 @@ git config [--global] "open.https://git.internal.biz.protocol" "http"
 ```
 
 
+### Browser options
+
+By default, `git open` uses your system's default browser (or the `BROWSER` environment variable if set). You can configure a specific browser globally or per URL pattern using git config's URL matching.
+
+`open.browser`
+  The default browser command to use for opening URLs.
+
+`open.[gitdomain].browser`
+  The browser command to use for URLs matching the given domain/path pattern. The most specific match wins.
+
+This is useful when you want to open different repositories in different browsers (e.g., work repos in Edge, personal repos in Safari).
+
+**Example**
+
+```sh
+# Default: open in Safari
+git config --global open.browser "open -a Safari"
+
+# Company repos: open in Edge
+git config --global "open.https://github.com/company-org.browser" "open -a 'Microsoft Edge'"
+
+# Self-hosted GitLab: open in Firefox
+git config --global "open.https://gitlab.internal.biz.browser" "open -a Firefox"
+```
+
+The `BROWSER` environment variable, if set, takes priority over all git config browser settings.
+
+
 ## DEBUGGING
 
 You can run `git-open` in `echo` mode, which doesn't open your browser, but just prints the URL to stdout:

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -701,6 +701,15 @@ setup() {
   assert_output "DEFAULT https://github.com/personal/repo"
 }
 
+@test "browser: handles quoted arguments in browser command" {
+  git remote set-url origin "git@github.com:user/repo.git"
+  git checkout -B "master"
+  git config --local open.browser "echo 'spaced arg'"
+  unset BROWSER
+  run ../git-open
+  assert_output "spaced arg https://github.com/user/repo"
+}
+
 @test "browser: BROWSER env var takes priority over config" {
   git remote set-url origin "git@github.com:user/repo.git"
   git checkout -B "master"


### PR DESCRIPTION
Fixes #229

## Summary

- Add `open.browser` and `open.<url>.browser` git config support, allowing different browsers for different URL patterns (e.g., Edge for work repos, Safari for personal)
- Use `eval` for the browser command to properly handle quoted arguments like `open -a 'Microsoft Edge'`
- Reuses the existing `getConfig` / `--get-urlmatch` mechanism — only 3 lines added to the script

## Example URLs being parsed

```
# With: git config "open.https://github.com/company-org.browser" "open -a 'Microsoft Edge'"
# Repo: git@github.com:company-org/repo.git
# Opens in: Microsoft Edge

# With: git config open.browser "open -a Safari"
# Repo: git@github.com:personal/repo.git
# Opens in: Safari (default fallback)
```

## Test plan

- [x] Default browser via `open.browser` config
- [x] URL-specific browser via `open.<url>.browser` config
- [x] URL-specific config overrides default config
- [x] Non-matching URL falls back to default browser config
- [x] Quoted arguments in browser command (e.g., `'Microsoft Edge'`)
- [x] `BROWSER` env var still takes priority over all config
- [x] All 73 existing + new tests pass