### PR TITLE
fix: normalize ssh.github.com to github.com for URL generation

### DIFF
--- a/git-open
+++ b/git-open
@@ -157,6 +157,11 @@ else
   fi
 fi
 
+# Normalize GitHub's SSH gateway hostname back to github.com for URL generation.
+# ssh.github.com is used when connecting via SSH over port 443 (GitHub's SSH-over-HTTPS gateway),
+# but the generated URL should still point to github.com.
+domain=${domain//ssh\.github\.com/github.com}
+
 # Trim "/" from beginning of URL; "/" and ".git" from end of URL
 urlpath=${urlpath#/} urlpath=${urlpath%/} urlpath=${urlpath%.git}
 


### PR DESCRIPTION
## Problem

When using GitHub's SSH-over-HTTPS gateway (configured via `~/.ssh/config`), the remote URL is returned as `ssh://git@ssh.github.com/...`, causing `git-open` to generate an invalid URL like `https://ssh.github.com/owner/repo` which cannot be opened in a browser.

This commonly happens when connecting to GitHub via SSH over port 443 (e.g., corporate networks that block port 22):

```ssh
Host github.com
    HostName ssh.github.com
    Port 443
```

## Fix

Normalize the `ssh.github.com` gateway hostname back to `github.com` before generating the browser URL.

## Before vs After

| Remote URL | Generated URL (before) | Generated URL (after) |
|---|---|---|
| `ssh://git@ssh.github.com/owner/repo` | ❌ `https://ssh.github.com/...` | ✅ `https://github.com/...` |
| `git@github.com:owner/repo` (no change) | ✅ `https://github.com/...` | ✅ `https://github.com/...` |