### PR TITLE
feat: support forge-specific branch URL formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,14 @@ git-open can automatically guess the corresponding repository page for remotes
 - GitLab custom hosted (see below)
 - bitbucket.org
 - Atlassian Bitbucket Server (formerly _Atlassian Stash_)
+- Gitea, Forgejo, Codeberg, and Gogs (see below)
 - Visual Studio Team Services
 - Team Foundation Server (on-premises)
 - AWS Code Commit
 - cnb.cool
+
+For Gitea, Forgejo, Codeberg, and Gogs instances, set `open.[gitdomain].forge`
+to the matching forge name so `git-open` uses the appropriate branch URL format.
 
 ## Configuration 
 
@@ -199,4 +203,3 @@ Copyright Jason McCreary & Paul Irish. Licensed under MIT.
 - **2016-07-23** - Readme: fix oh-my-zsh install instructions
 - **2016-07-22** - 1.1.0 shipped. update and add linters for package.json, readme.
 - **2016-07-11** - Readme formatting and installation instructions updated. Changelog started
-

--- a/git-open
+++ b/git-open
@@ -191,11 +191,17 @@ else
   # Make # and % characters url friendly
   #   github.com/paulirish/git-open/pull/24
   remote_ref=${remote_ref//%/%25} remote_ref=${remote_ref//#/%23}
-  if [[ $forge == 'gitea' ]]; then
-    providerBranchRef="/src/branch/$remote_ref"
-  else
-    providerBranchRef="/tree/$remote_ref"
-  fi
+  case "$forge" in
+    gitea|forgejo|codeberg)
+      providerBranchRef="/src/branch/$remote_ref"
+      ;;
+    gogs)
+      providerBranchRef="/src/$remote_ref"
+      ;;
+    *)
+      providerBranchRef="/tree/$remote_ref"
+      ;;
+  esac
 fi
 
 if [[ "$domain" == 'bitbucket.org' ]]; then

--- a/git-open.1.md
+++ b/git-open.1.md
@@ -90,6 +90,7 @@ on the following git hosting services:
 - GitLab CE/EE (self hosted GitLab, see `CONFIGURATION`)
 - bitbucket.org
 - Atlassian Bitbucket Server (formerly _Atlassian Stash_)
+- Gitea, Forgejo, Codeberg, and Gogs (see `CONFIGURATION`)
 - Visual Studio Team Services
 - Team Foundation Server (on-premises)
 
@@ -118,17 +119,19 @@ git config open.default.remote upstream
 This is equivalent to always typing `git open upstream`.
 
 
-### Gitea options
+### Forge options
 
-To configure Gitea support you need to set the following option.
+To configure Gitea, Forgejo, Codeberg or Gogs support you need to set the following option.
 
 `open.[gitdomain].forge`
-  The git forge present at the git domain. This only needs to be set for Gitea because it uses another branch URL format.
+  The git forge present at the git domain. This only needs to be set for hosts that do not use the default `/tree/<branch>` branch URL format.
 
 **Example**
 
 ```sh
 git config [--global] "open.https://gitea.internal.biz.forge" "gitea"
+git config [--global] "open.https://codeberg.org.forge" "codeberg"
+git config [--global] "open.http://localhost:3000.forge" "gogs"
 ```
 
 

--- a/test/git-open.bats
+++ b/test/git-open.bats
@@ -559,6 +559,42 @@ setup() {
 }
 
 ##
+## Gitea / Forgejo / Codeberg / Gogs
+##
+
+@test "forge: codeberg branch" {
+  git remote set-url origin "git@codeberg.org:user/repo.git"
+  git config --local "open.https://codeberg.org.forge" "codeberg"
+  git checkout -B "mybranch"
+  run ../git-open
+  assert_output "https://codeberg.org/user/repo/src/branch/mybranch"
+}
+
+@test "forge: gitea branch" {
+  git remote set-url origin "git@gitea.example.com:user/repo.git"
+  git config --local "open.https://gitea.example.com.forge" "gitea"
+  git checkout -B "mybranch"
+  run ../git-open
+  assert_output "https://gitea.example.com/user/repo/src/branch/mybranch"
+}
+
+@test "forge: forgejo branch" {
+  git remote set-url origin "git@forgejo.example.com:user/repo.git"
+  git config --local "open.https://forgejo.example.com.forge" "forgejo"
+  git checkout -B "mybranch"
+  run ../git-open
+  assert_output "https://forgejo.example.com/user/repo/src/branch/mybranch"
+}
+
+@test "forge: gogs branch" {
+  git remote set-url origin "http://localhost:3000/user/repo.git"
+  git config --local "open.http://localhost:3000.forge" "gogs"
+  git checkout -B "mybranch"
+  run ../git-open
+  assert_output "http://localhost:3000/user/repo/src/mybranch"
+}
+
+##
 ## Visual Studio Team Services
 ##
 


### PR DESCRIPTION
Handle forge-specific branch URLs for Forgejo, Codeberg, and Gogs.

This updates `git-open` to generate the correct branch URL format for these forges:
- Gitea, Forgejo, and Codeberg: `/src/branch/<branch>`
- Gogs: `/src/<branch>`

Also updates the documentation and adds test coverage for the new forge-specific behavior.